### PR TITLE
Set the custom modules directory correctly in D7.

### DIFF
--- a/provisioning/tasks/drupal.yml
+++ b/provisioning/tasks/drupal.yml
@@ -45,10 +45,10 @@
     drupal_custom_modules_path: "{{ drupal_core_path }}/sites/all/modules/custom"
   when: drupal_major_version < 8
 
-- name: Set the custom module directory path for Drupal < 8.
+- name: Set the custom module directory path for Drupal = 8.
   set_fact:
     drupal_custom_modules_path: "{{ drupal_core_path }}/modules/custom"
-  when: drupal_major_version <= 8
+  when: drupal_major_version = 8
 
 - name: Symlink custom modules directory into place.
   file: >


### PR DESCRIPTION
After reading the drupal.yml task, I checked.  Sure enough, the custom modules were under `/var/www/drupal/modules/custom_modules/` on the VM.
