### PR TITLE
D7 module dir

### DIFF
--- a/provisioning/tasks/drupal.yml
+++ b/provisioning/tasks/drupal.yml
@@ -43,12 +43,12 @@
 - name: Set the custom module directory path for Drupal < 8.
   set_fact:
     drupal_custom_modules_path: "{{ drupal_core_path }}/sites/all/modules/custom"
-  when: drupal_major_version < 8
+  when: drupal_major_version|int < 8
 
 - name: Set the custom module directory path for Drupal = 8.
   set_fact:
     drupal_custom_modules_path: "{{ drupal_core_path }}/modules/custom"
-  when: drupal_major_version = 8
+  when: drupal_major_version|int == 8
 
 - name: Symlink custom modules directory into place.
   file: >


### PR DESCRIPTION
There were two mistakes in the lines that create the custom-modules directory:
1. They both used the same condition.  (Too much copy and paste?)
2. They compared variables as the default (string) and not as integers.
