### PR TITLE
add NFS server as Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This Quick Start Guide will help you quickly build a Drupal 8 site on the Drupal
   1. Download and install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) (Drupal VM also works with VMware, if you have the [Vagrant VMware integration plugin](http://www.vagrantup.com/vmware)).
   2. Download and install [Vagrant](http://www.vagrantup.com/downloads.html).
   3. [Mac/Linux only] Install [Ansible](http://docs.ansible.com/intro_installation.html).
+  4. Install NFS server in host machine. eg: for [Ubuntu host](https://www.digitalocean.com/community/tutorials/how-to-set-up-an-nfs-mount-on-ubuntu-14-04)
 
 Note for Windows users: *Ansible will be installed inside the VM, and everything will be configured internally (unlike on Mac/Linux hosts). See [JJG-Ansible-Windows](https://github.com/geerlingguy/JJG-Ansible-Windows) for more information.*
 


### PR DESCRIPTION
Not every host machine has NFS kernel server installed. I got stuck here several times using Ubuntu 14.04 as host, prompting to error:
```js
==> drupaldev: Destroying VM and associated drives...
/opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/mixin_synced_folders.rb:113:in `block in synced_folders': Internal error. Report this as a bug. Invalid: nfs (RuntimeError)
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/mixin_synced_folders.rb:101:in `each'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/mixin_synced_folders.rb:101:in `synced_folders'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/synced_folder_cleanup.rb:19:in `call'

```

In some cases, it prompts to ask root password for host machine to install NFS, but again gets stuck in limbo. Asking for **root password** while running virtual machine in vagrant is not desired option really, so, its better to inform users to Install NFS by themselves beforehand. 