### PR TITLE
Clarify credentials for logging into site

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Note: *If there are any errors during the course of running `vagrant up`, and it
 
   1. [Edit your hosts file](http://www.rackspace.com/knowledge_center/article/how-do-i-modify-my-hosts-file), adding the line `192.168.88.88  drupaltest.dev` so you can connect to the VM.
   2. Open your browser and access [http://drupaltest.dev/](http://drupaltest.dev/).
+  3. The default username/password combination should be "admin/admin" to login to your test site.
 
 ## Extra software/utilities
 


### PR DESCRIPTION
I initially tried "drupal/drupal" for a username and password combo since it was used for MySQL credentials, but I didn't see anywhere where the Drupal admin credentials were mentioned. This final part could be a little confusing for people just getting into setting up VM local development like myself.