### PR TITLE
Improved example

### DIFF
--- a/example.drupal.make.yml
+++ b/example.drupal.make.yml
@@ -9,16 +9,12 @@ core: "8.x"
 
 projects:
 
-  # Use the latest drupal release.
+  # Get a drupal copy to work on.
   drupal:
-    version: ~
-
-  # Get a module to work on.
-  honeypot:
-    type: "module"
+    type: "core"
     download:
+      branch: "8.0.x"
       working-copy: true
-      branch: "8.x-1.x"
 
-  # Add other modules.
+  # Add extra modules.
   devel: "1.x-dev"

--- a/example.drupal.make.yml
+++ b/example.drupal.make.yml
@@ -9,10 +9,16 @@ core: "8.x"
 
 projects:
 
+  # Use the latest drupal release.
   drupal:
-    type: "core"
-    version: "8.0.x"
+    version: ~
+
+  # Get a module to work on.
+  honeypot:
+    type: "module"
     download:
       working-copy: true
+      branch: "8.x-1.x"
 
+  # Add other modules.
   devel: "1.x-dev"


### PR DESCRIPTION
Getting a working copy of the drupal project means you always get the default branch.
You should never specify `version` on git downloads, only branches or commits.