### PR TITLE
Add Adminer as an alternative db tool.

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -76,6 +76,7 @@ installed_extras:
   # - solr
   - xdebug
   - xhprof
+  # - adminer
 
 # Add any extra apt packages you'd like to install.
 extra_apt_packages: []
@@ -126,3 +127,6 @@ php_xdebug_default_enable: 0
 solr_version: "4.10.4"
 solr_xms: "64M"
 solr_xmx: "128M"
+
+# Adminer settings
+adminer_install_dirs: ["/var/www"]

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -32,6 +32,7 @@
     - { role: geerlingguy.mailhog, when: '"mailhog" in installed_extras' }
     - { role: geerlingguy.java, when: '"solr" in installed_extras' }
     - { role: geerlingguy.solr, when: '"solr" in installed_extras' }
+    - { role: tersmitten.adminer, when: '"adminer" in installed_extras' }
 
     # Roles for security and stability on production.
     - { role: geerlingguy.security, when: extra_security_enabled }

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ geerlingguy.mailhog
 geerlingguy.java
 geerlingguy.solr
 geerlingguy.security
+tersmitten.adminer


### PR DESCRIPTION
Hi I think it would be nice to have [Adminer](http://www.adminer.org) as a lightweight one-file alternative to PHPmyadmin - this should be easy enough as there already ansible role for this and it requires no configuration at all.