### PR TITLE
"config.yml missing" even when it exists

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,10 +4,11 @@ VAGRANTFILE_API_VERSION = "2"
 
 # Use config.yml for basic VM configuration.
 require 'yaml'
-if !File.exist?('./config.yml')
+dir = File.dirname(File.expand_path(__FILE__))
+if !File.exist?("#{dir}/config.yml")
   raise 'Configuration file not found! Please copy example.config.yml to config.yml and try again.'
 end
-vconfig = YAML::load_file("./config.yml")
+vconfig = YAML::load_file("#{dir}/config.yml")
 
 # Use rbconfig to determine if we're on a windows host or not.
 require 'rbconfig'


### PR DESCRIPTION
When trying to run a Vagrant command (e.g. "vagrant ssh") from a different directory in the project aside from the root one where the Vagrantfile lives, the command will fail even though config.yml exists.

> Path: /Users/opdavies/Code/Current/Personal/dcbristol15/Vagrantfile
Message: Configuration file not found! Please copy example.config.yml to config.yml and try again.

I've added some extra code to Vagrantfile to make sure that we're looking in the correct place for config.yml, rather than in the directory that we're in when we run the command.