### PR TITLE
Allow Vagrantfile to be loaded from separate script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,13 +46,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if is_windows
     # Provisioning configuration for shell script (for Windows).
     config.vm.provision "shell" do |sh|
-      sh.path = "provisioning/JJG-Ansible-Windows/windows.sh"
-      sh.args = "provisioning/playbook.yml"
+      sh.path = "#{dir}/provisioning/JJG-Ansible-Windows/windows.sh"
+      sh.args = "#{dir}/provisioning/playbook.yml"
     end
   else
     # Provisioning configuration for Ansible (for Mac/Linux hosts).
     config.vm.provision "ansible" do |ansible|
-      ansible.playbook = "provisioning/playbook.yml"
+      ansible.playbook = "#{dir}/provisioning/playbook.yml"
       ansible.sudo = true
     end
   end


### PR DESCRIPTION
I wanted to include this repository as a sub directory in my own project and delegate the Vagrantfile from my project root.

```ruby
dir = File.dirname(__FILE__) + '/'
load dir + "drupal-vm/Vagrantfile"
```
Currently this does not work as the provisioning paths are relative. 