### PR TITLE
Add drupal install arguments configuration option

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -49,6 +49,9 @@ drupal_mysql_user: drupal
 drupal_mysql_password: drupal
 drupal_mysql_database: drupal
 
+# Additional arguments or options to pass to `drush site-install`.
+drupal_site_install_extra_args: []
+
 # Cron jobs are added to the root user's crontab. Keys include name (required),
 # minute, hour, day, weekday, month, job (required), and state.
 drupalvm_cron_jobs: []

--- a/provisioning/tasks/install-site.yml
+++ b/provisioning/tasks/install-site.yml
@@ -15,6 +15,7 @@
     --account-name={{ drupal_account_name }}
     --account-pass={{ drupal_account_pass }}
     --db-url=mysql://{{ drupal_mysql_user }}:{{ drupal_mysql_password }}@localhost/{{ mysql_databases[0].name }}
+    {{ drupal_site_install_extra_args | default([]) | join(" ") }}
     chdir={{ drupal_core_path }}
   notify: restart webserver
   when: "'Successful' not in drupal_site_installed.stdout"


### PR DESCRIPTION
Would be useful to allow additional arguments to be passed to the `drush site-install` command.

In my case I'd like to install the commerce kickstart distribution without the demo store.