### PR TITLE
vagrant-auto_network plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Note: *If there are any errors during the course of running `vagrant up`, and it
 ### 3 - Configure your host machine to access the VM.
 
   1. [Edit your hosts file](http://www.rackspace.com/knowledge_center/article/how-do-i-modify-my-hosts-file), adding the line `192.168.88.88  drupalvm.dev` so you can connect to the VM. Alternatively, you can install a Vagrant plugin to automatically add and remove the entry from your hosts file; run `vagrant plugin install vagrant-hostsupdater`. The plugin will also add in all other hosts defined via `apache_vhosts`.
+    - You can have vagrant automatically assign IP addresses to your VM by adding the vagrant-auto_network plugin (`vagrant plugin install vagrant-auto_network`).
+    - To use the vagrant-auto_network plugin, set the vagrant_ip setting in your config.yml file to "0.0.0.0"
+      NOTE: You will want to use the vagrant-hostsupdater plugin in combination with vagrant-auto_network.
   2. Open your browser and access [http://drupalvm.dev/](http://drupalvm.dev/). The default login for the admin account is `admin` for both the username and password.
 
 ## Extra software/utilities

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,11 @@ is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = vconfig['vagrant_hostname']
-  config.vm.network :private_network, ip: vconfig['vagrant_ip']
+  if vconfig['vagrant_ip'] == "0.0.0.0" && Vagrant.has_plugin?("vagrant-auto_network")
+    config.vm.network :private_network, :ip => "0.0.0.0", :auto_network => true
+  else
+    config.vm.network :private_network, ip: vconfig['vagrant_ip']
+  end
   config.ssh.insert_key = false
   config.ssh.forward_agent = true
 


### PR DESCRIPTION
This update makes a small modification to the Vagrantfile to detect if the user has the vagrant-auto_network plugin installed and uses that to automatically assign an IP address to the VM rather than having to explicitly set an IP in the config.yml file.  This is useful for users that need to run multiple VM as it helps avoid IP address collisions or having to track which IPs are used by which VMs.