### PR TITLE
Add swappiness task

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -156,10 +156,11 @@ solr_version: "4.10.4"
 solr_xms: "64M"
 solr_xmx: "128M"
 
-# By default, linux sets the swappiness level to 60, this means that some swapping will occur.
-# Swapping will slow down any system, but in a virtual environment, when the guest stars
-# swapping, things will become even more slow than normal. As such, setting the swappiness
-# to 0 will cause the linux kernel to only swap to avoid out of memory situations, this will
-# prevent early swapping of application memory, which in turn will dramatically improve performance
-# of the virtual machine, even on lower powered hosts.
+# By default, linux sets the swappiness level to 60, this means that some
+# swapping will occur. Swapping will slow down any system, but in a virtual
+# environment, when the guest starts swapping, things will become even more
+# slow than normal. As such, setting the swappiness to 0 will cause the linux
+# kernel to only swap to avoid out of memory situations, this will prevent
+# early swapping of application memory, which in turn will dramatically
+# improve performance of the virtual machine, even on lower powered hosts.
 swappiness: "0"

--- a/example.config.yml
+++ b/example.config.yml
@@ -155,3 +155,11 @@ php_xdebug_default_enable: 0
 solr_version: "4.10.4"
 solr_xms: "64M"
 solr_xmx: "128M"
+
+# By default, linux sets the swappiness level to 60, this means that some swapping will occur.
+# Swapping will slow down any system, but in a virtual environment, when the guest stars
+# swapping, things will become even more slow than normal. As such, setting the swappiness
+# to 0 will cause the linux kernel to only swap to avoid out of memory situations, this will
+# prevent early swapping of application memory, which in turn will dramatically improve performance
+# of the virtual machine, even on lower powered hosts.
+swappiness: "0"

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -47,6 +47,7 @@
 
     - include: tasks/extras.yml
     - include: tasks/www.yml
+    - include: tasks/set-swappiness.yml
     - include: tasks/apparmor.yml
       when: ansible_os_family == 'Debian'
 

--- a/provisioning/tasks/set-swappiness.yml
+++ b/provisioning/tasks/set-swappiness.yml
@@ -1,0 +1,12 @@
+---
+- name: Set swappiness value
+  command: >
+    sed -i '$a vm.swappiness = {{ swappiness }}' /etc/sysctl.conf 
+  when: 1
+  sudo: yes
+
+- name: Reload sysctl config
+  command: >
+    sysctl -p
+  when: 1
+  sudo: yes


### PR DESCRIPTION
This PR adds a task to allow configuration of the swappiness value of the guest OS. By default, Linux sets this value to 60, which means some swapping will always occur.  Swapping slows down the system, and in a virtual guest environment this very quickly becomes a performance issue. When the guest swaps, everything usually slows down, both inside the guest os and on the host. Setting swappiness to 0 will cause the linux kernel to only swap to avoid out of memory situations, but even a higher value (that is still considerably lower than the default) like 10 will result is a dramatic increase to responsiveness of the virtual machine in most cases -- especially when configured with more limited resources.