### PR TITLE
add support for custom synced folder mount options

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,7 +40,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       rsync__exclude: synced_folder['excluded_paths'],
       rsync__args: ["--verbose", "--archive", "--delete", "-z", "--chmod=ugo=rwX"],
       id: synced_folder['id'],
-      create: synced_folder.include?('create') ? synced_folder['create'] : false
+      create: synced_folder.include?('create') ? synced_folder['create'] : false,
+      mount_options: synced_folder.include?('mount_options') ? synced_folder['mount_options'] : []
   end
 
   if is_windows


### PR DESCRIPTION
I read your article about rsync vs nfs–a very interesting read. I tried switching to it but in the end I decided to stick to NFS due to the long sync delays (annoying while editing css for example).

To get instant sync (and hopefully some other performance benefits) I needed to add the following mount options to the synced_folders `nolock,vers=3,udp,noatime,actimeo=1'`

Hence this patch.