### PR TITLE
Use drupal_domain for extra vhosts

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -66,8 +66,8 @@ configure_local_drush_aliases: true
 # multisite deployments, you can point multiple servernames at one documentroot.
 apache_vhosts:
   - {servername: "{{ drupal_domain }}", documentroot: "{{ drupal_core_path }}"}
-  - {servername: "xhprof.drupalvm.dev", documentroot: "/usr/share/php/xhprof_html"}
-  - {servername: "pimpmylog.drupalvm.dev", documentroot: "/usr/share/php/pimpmylog"}
+  - {servername: "xhprof.{{ drupal_domain }}", documentroot: "/usr/share/php/xhprof_html"}
+  - {servername: "pimpmylog.{{ drupal_domain }}", documentroot: "/usr/share/php/pimpmylog"}
 apache_remove_default_vhost: true
 apache_mods_enabled:
   - expires.load

--- a/example.config.yml
+++ b/example.config.yml
@@ -65,9 +65,9 @@ configure_local_drush_aliases: true
 # Apache VirtualHosts. Add one for each site you are running inside the VM. For
 # multisite deployments, you can point multiple servernames at one documentroot.
 apache_vhosts:
-  - {servername: "{{ drupal_domain }}", documentroot: "{{ drupal_core_path }}"}
-  - {servername: "xhprof.{{ drupal_domain }}", documentroot: "/usr/share/php/xhprof_html"}
-  - {servername: "pimpmylog.{{ drupal_domain }}", documentroot: "/usr/share/php/pimpmylog"}
+  - { servername: "{{ drupal_domain }}", documentroot: "{{ drupal_core_path }}" }
+  - { servername: "xhprof.{{ drupal_domain }}", documentroot: "/usr/share/php/xhprof_html" }
+  - { servername: "pimpmylog.{{ drupal_domain }}", documentroot: "/usr/share/php/pimpmylog" }
 apache_remove_default_vhost: true
 apache_mods_enabled:
   - expires.load


### PR DESCRIPTION
Use the drupal_domain variable to the extra vhost servernames.

Also, added some extra spaces to make it easier to read. :)