### PR TITLE
Added support for autohosts with ansible variables.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,10 +29,31 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # If hostsupdater plugin is installed, add all servernames as aliases.
   if Vagrant.has_plugin?("vagrant-hostsupdater")
     config.hostsupdater.aliases = []
+
+    # Add in the drupal_domain if it is different from vagrant_hostname.
+    if vconfig['drupal_domain'] != config.vm.hostname
+      config.hostsupdater.aliases.push(vconfig['drupal_domain'])
+    end
+
+    # Add hosts for all server names and aliases that are not the same
+    # as vagrant_hostname.
     for host in vconfig['apache_vhosts']
-      # Add all the hosts that aren't defined as Ansible vars.
-      unless host['servername'].include? "{{"
-        config.hostsupdater.aliases.push(host['servername'])
+      # Vhost server name.
+      servername = host['servername'].sub('{{ drupal_domain }}', vconfig['drupal_domain'])
+      if servername != config.vm.hostname && !config.hostsupdater.aliases.index(servername)
+        config.hostsupdater.aliases.push(servername)
+      end
+
+      # Vhost server aliases.
+      # Can be a space deliminated list of host names, so we have to iterate over them.
+      if host['serveralias'] && !host['serveralias'].empty?
+        serveraliases = host['serveralias'].gsub('{{ drupal_domain }}', vconfig['drupal_domain'])
+        server_alias_array = serveraliases.split(' ')
+        for server_alias in server_alias_array
+          if server_alias != config.vm.hostname && !config.hostsupdater.aliases.index(server_alias)
+            config.hostsupdater.aliases.push(server_alias)
+          end          
+        end
       end
     end
   end

--- a/example.config.yml
+++ b/example.config.yml
@@ -64,10 +64,12 @@ configure_local_drush_aliases: true
 
 # Apache VirtualHosts. Add one for each site you are running inside the VM. For
 # multisite deployments, you can point multiple servernames at one documentroot.
+# You can also specify alternate aliases for each vhost by adding the serveralias
+#   ex: serveralias: "www.{{ drupal_domain }} forum.{{ drupal_domain }}"
 apache_vhosts:
   - {servername: "{{ drupal_domain }}", documentroot: "{{ drupal_core_path }}"}
-  - {servername: "xhprof.drupalvm.dev", documentroot: "/usr/share/php/xhprof_html"}
-  - {servername: "pimpmylog.drupalvm.dev", documentroot: "/usr/share/php/pimpmylog"}
+  - {servername: "xhprof.{{ drupal_domain }}", documentroot: "/usr/share/php/xhprof_html"}
+  - {servername: "pimpmylog.{{ drupal_domain }}", documentroot: "/usr/share/php/pimpmylog"}
 apache_remove_default_vhost: true
 apache_mods_enabled:
   - expires.load


### PR DESCRIPTION
This is related to the following issues and Pull Requests:
* https://github.com/geerlingguy/drupal-vm/pull/182
* https://github.com/geerlingguy/drupal-vm/issues/143

This PR updates the Vagrantfile logic for the hostsupdater plugin to support adding host file entries for the following:
* Apache vhost servername with the {{ drupal_domain}} ansible variable in them.
* Apache vhost serveralias with the {{ drupal_domain}} ansible variable.
* Catches an edge case when a user configures their vm host name to be different than the drupal host name.

NOTE: My Ruby/Ansible skills aren't as strong as in some other languages.  So I welcome any feedback or suggestions on better ways of implementing this update. :-)