### PR TITLE
Update documentation for xhprof and pimpmylog urls

### DIFF
--- a/docs/extras/pimpmylog.md
+++ b/docs/extras/pimpmylog.md
@@ -1,8 +1,8 @@
-[Pimp my Log](http://pimpmylog.com/) is a PHP-based web GUI for viewing log files on a given server. By default, it is installed on Drupal VM, and you can access it at the URL `http://local.pimpmylog.com/` (as long as you have a hosts entry for that URL pointing at Drupal VM's IP address!).
+[Pimp my Log](http://pimpmylog.com/) is a PHP-based web GUI for viewing log files on a given server. By default, it is installed on Drupal VM, and you can access it at the URL `http://pimpmylog.drupalvm.dev/` (as long as you have a hosts entry for that URL pointing at Drupal VM's IP address!).
 
 By default, it will find the default Apache 2 `access.log` and `error.log` files, but it will not find other logs, like MySQL or extra Apache virtualhost logs.
 
-When configuring Pimp my Log (on the first visit to the `local.pimpmylog.com` URL), you can add extra paths in the UI, or you can add them after the fact by manually editing the configuration file, which by default is stored at `/usr/share/php/pimpmylog/config.user.php`. You can also delete that file and re-configure Pimp my Log via the web UI.
+When configuring Pimp my Log (on the first visit to the `pimpmylog.drupalvm.dev` URL), you can add extra paths in the UI, or you can add them after the fact by manually editing the configuration file, which by default is stored at `/usr/share/php/pimpmylog/config.user.php`. You can also delete that file and re-configure Pimp my Log via the web UI.
 
 Some log files you may be interested in monitoring:
 

--- a/docs/extras/xhprof.md
+++ b/docs/extras/xhprof.md
@@ -11,4 +11,4 @@ The XHProf module doesn't yet include support for callgraphs, but there's an iss
 The Devel module also *used* to provide XHProf configuration, and setting the options below would allow Devel's XHProf integration to work correctly with Drupal VM's XHProf installation:
 
   - **xhprof directory**: `/usr/share/php`
-  - **XHProf URL**: `http://local.xhprof.com/` (assuming this domain is configured in `apache_vhosts` inside `config.yml`)
+  - **XHProf URL**: `http://xhprof.drupalvm.dev/` (assuming this domain is configured in `apache_vhosts` inside `config.yml`)


### PR DESCRIPTION
Updates the documentarians for xhprof and pimpmylog extras. The vhost aliases have changed at some point from the http://local. urls and the supporting documentation should match.