### PR TITLE
Avoid Drupal installer exception for xdebug nesting level

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -163,7 +163,7 @@ php_xdebug_remote_enable: 1
 php_xdebug_remote_connect_back: 1
 # Use PHPSTORM for PHPStorm, sublime.xdebug for Sublime Text.
 php_xdebug_idekey: PHPSTORM
-php_xdebug_max_nesting_level: 255
+php_xdebug_max_nesting_level: 256
 
 # Solr Configuration (if enabled above).
 solr_version: "4.10.4"


### PR DESCRIPTION
```
Exception 'Drupal\Core\Installer\Exception\InstallerException' with message 'Xdebug settings: xdebug.max_nesting_level is set to 255.

Set xdebug.max_nesting_level=256 in your PHP configuration as some pages in your Drupal site will not work when
this setting is too low.' in /var/www/drupal/core/includes/install.core.inc:2292
```