### PR TITLE
Set example mysql_wait_timeout to 300.

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -143,6 +143,7 @@ composer_home_path: '/home/vagrant/.composer'
 mysql_root_password: root
 mysql_slow_query_log_enabled: true
 mysql_slow_query_time: 2
+mysql_wait_timeout: 300
 adminer_add_apache_config: true
 
 # Varnish Configuration.


### PR DESCRIPTION
## Motivation
mySQL's default wait timeout is crazy high. (see also http://www.eliotk.net/12/21/mysql-wait_timeout-default-is-set-too-high/)

No need to keep connections open for 8 hours by default.

## Notes
I thought about putting this in the mysql playbook as a default, but since it _is_ mySQL's default, I figured this makes more sense.