### PR TITLE
Add a bit more explanation to the extra_packages variable

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -100,7 +100,9 @@ installed_extras:
   - xdebug
   - xhprof
 
-# Add any extra packages you'd like to install.
+# Add any extra apt or yum packages. Use the apt or yum package name to
+# indicate which package you'd like to install. E.g. the unzip apt package is
+# used by Drush to unzip libraries downloaded by Drush make files. 
 extra_packages: []
 
 # You can configure almost anything else on the server in the rest of this file.


### PR DESCRIPTION
Today I ran into the extra_packages variables in my config.yml file. I had a hunch that it could be of use to me, but I had to track it back a bit to `provisioning/tasks/extras.yml` and to [this ticket](https://github.com/geerlingguy/drupal-vm/issues/62) to understand what it exactly does. 

In my case it was perfect to provision the unzip package (for usage in downloading libraries by Drush make files). So, I propose to add a bit more explanation to the variable to make it more clear on how to use it and what it expects. 