### PR TITLE
Pass the port number from the Vagrant autogenerated inventory

### DIFF
--- a/provisioning/templates/drupalvm.aliases.drushrc.php.j2
+++ b/provisioning/templates/drupalvm.aliases.drushrc.php.j2
@@ -12,7 +12,7 @@ $aliases['{{ vhost.servername }}'] = array(
   'root' => '{{ vhost.documentroot }}',
   'remote-host' => '{{ vhost.servername }}',
   'remote-user' => 'vagrant',
-  'ssh-options' => '-o PasswordAuthentication=no -i ~/.vagrant.d/insecure_private_key',
+  'ssh-options' => '-p {{ ansible_ssh_port }} -o PasswordAuthentication=no -i ~/.vagrant.d/insecure_private_key',
 );
 
 {% endfor %}


### PR DESCRIPTION
The ansible vagrant plugin automatically writes an inventory file with the ssh-config options needed to connect to the vm instance. When one has more than 1 VMs running on the host the chance in this PR will ensure that vagrant provision will still work.

Inventory file sits at .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory

There's also a "ansible_ssh_host" variable which I suspect would be a better fit for the 'remote-host' value rather than what we have now? This would mean that even if one does not setup their hosts file on the host, drush aliases will still work for that website.