### PR TITLE
Fixes #203: Only use Ondrej repo for Ubuntu 12.04 when installing 5.5.

### DIFF
--- a/provisioning/tasks/init-debian.yml
+++ b/provisioning/tasks/init-debian.yml
@@ -18,7 +18,7 @@
 
 - name: Add repository for PHP 5.5.
   apt_repository: repo='ppa:ondrej/php5'
-  when: php_version == "5.5"
+  when: php_version == "5.5" and ansible_distribution_version == "12.04"
 
 - name: Add repository for PHP 5.6.
   apt_repository: repo='ppa:ondrej/php5-5.6'


### PR DESCRIPTION
See: #203 