### PR TITLE
added drush extras to the extras task

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -110,6 +110,8 @@ extra_security_enabled: false
 drush_version: master
 drush_keep_updated: true
 drush_composer_cli_options: "--prefer-dist --no-interaction"
+drush_global_modules:
+  - registry_rebuild
 
 firewall_allowed_tcp_ports:
   - "22"

--- a/provisioning/tasks/extras.yml
+++ b/provisioning/tasks/extras.yml
@@ -8,3 +8,9 @@
   yum: "name={{ item }} state=installed"
   with_items: extra_packages | list
   when: ansible_os_family == 'RedHat' and extra_packages | length
+
+- name: Install extra drush modules.
+  command: >
+    {{ drush_path }} dl {{item}}
+  with_items: drush_global_modules
+  sudo: no


### PR DESCRIPTION
This will add the ability to add global drush modules through the config.yml

In the example I am adding registry_rebuild to the vagrant box, but this could also be used to add module builder or any other drush module that isn't necessarily a part of a drupal site.