### PR TITLE
Add variable to use ansible in vm as a preference.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,7 +64,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   # Provision using Ansible provisioner if Ansible is installed on host.
-  if which('ansible-playbook')
+  if which('ansible-playbook') && !vconfig['ansbile_in_vm_preferred']
     config.vm.provision "ansible" do |ansible|
       ansible.playbook = "#{dir}/provisioning/playbook.yml"
       ansible.sudo = true


### PR DESCRIPTION
Adding a variable to use ansible installation in the vm even if ansible exists on the host.

It allows to set a variable in the config file to choose to run ansible in the vm.

```
# ansible installed in vm preferred
ansbile_in_vm_preferred: true
```

This should change nothing for existing installations and config files.  Although the example config file could have the variable defined as false.

```
# ansible installed in vm preferred
ansbile_in_vm_preferred: false
```