### PR TITLE
Revert "Pass the port number from the Vagrant autogenerated inventory"

### DIFF
--- a/provisioning/templates/drupalvm.aliases.drushrc.php.j2
+++ b/provisioning/templates/drupalvm.aliases.drushrc.php.j2
@@ -12,7 +12,7 @@ $aliases['{{ vhost.servername }}'] = array(
   'root' => '{{ vhost.documentroot }}',
   'remote-host' => '{{ vhost.servername }}',
   'remote-user' => 'vagrant',
-  'ssh-options' => '-p {{ ansible_ssh_port }} -o PasswordAuthentication=no -i ~/.vagrant.d/insecure_private_key',
+  'ssh-options' => '-o PasswordAuthentication=no -i ~/.vagrant.d/insecure_private_key',
 );
 
 {% endfor %}


### PR DESCRIPTION
Reverts geerlingguy/drupal-vm#202

See rationale in https://github.com/geerlingguy/drupal-vm/issues/259