### PR TITLE
Add task and variable to disable pre-installed Drupal modules.

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -50,6 +50,7 @@ drupal_domain: "drupalvm.dev"
 drupal_site_name: "Drupal"
 drupal_install_profile: standard
 drupal_enable_modules: [ 'devel' ]
+drupal_disable_modules: []
 drupal_account_name: admin
 drupal_account_pass: admin
 drupal_mysql_user: drupal

--- a/provisioning/tasks/install-site.yml
+++ b/provisioning/tasks/install-site.yml
@@ -27,3 +27,10 @@
     chdir={{ drupal_core_path }}
   when: "'Successful' not in drupal_site_installed.stdout"
   sudo: no
+
+- name: Disable pre-installed modules with drush.
+  command: >
+    {{ drush_path }} pm-disable -y {{ drupal_disable_modules | join(" ") }}
+    chdir={{ drupal_core_path }}
+  when: "'Successful' not in drupal_site_installed.stdout"
+  sudo: no


### PR DESCRIPTION
With this functionnality, we can disable pre-installed Drupal modules that are no longer useful because of other modules enabled with the variable `drupal_enable_modules`. For instance, we have to disable `toolbar` when using `admin_menu`, otherwise two toolbars are visible.

Example of configuration (4 modules to disable):
```
drupal_disable_modules: [ 'color help overlay toolbar' ]
```