### PR TITLE
Solve nfs permissions issues

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   for synced_folder in vconfig['vagrant_synced_folders'];
+    case synced_folder['type']
+    when "nfs"
+      if Vagrant.has_plugin?("vagrant-bindfs")
+        config.bindfs.bind_folder "/var/nfs", synced_folder["destination"]
+        synced_folder['destination'] = "/var/nfs"
+      end
+      config.nfs.map_uid = Process.uid
+      config.nfs.map_gid = Process.gid
+    end
+
     config.vm.synced_folder synced_folder['local_path'], synced_folder['destination'],
       type: synced_folder['type'],
       rsync__auto: "true",


### PR DESCRIPTION
Include vagrant-bindfs plugin.
When I try to use drupal-vm on MacOS X El Capitan, I get errors with folder perms using nfs. So I've found nearly a solution in this issue https://www.drupal.org/node/2485869
![1 vagrant-ssh-with-wrong-perms](https://cloud.githubusercontent.com/assets/791060/10712668/6e1cd990-7aa9-11e5-91f8-86f160a46f5a.png)
And after I've changed a little bit a Vagrantfile shared folder was mounted with vagrant:vagrant ownership and nginx stopped return 404 error.

Also I've found this thread https://groups.google.com/forum/#!topic/vagrant-up/qXXJ-AQuKQM but haven't yet tested.