### PR TITLE
Ruby coding style fixes via rubocop in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,36 +1,38 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
-VAGRANTFILE_API_VERSION = "2"
+VAGRANTFILE_API_VERSION = '2'
+
+require 'yaml'
 
 # Cross-platform way of finding an executable in the $PATH.
 def which(cmd)
   exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
   ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
-    exts.each { |ext|
+    exts.each do |ext|
       exe = File.join(path, "#{cmd}#{ext}")
       return exe if File.executable?(exe) && !File.directory?(exe)
-    }
+    end
   end
-  return nil
+  nil
 end
 
 # Use config.yml for basic VM configuration.
-require 'yaml'
 dir = File.dirname(File.expand_path(__FILE__))
-if !File.exist?("#{dir}/config.yml")
+begin
+  vconfig = YAML.load_file("#{dir}/config.yml")
+rescue Errno::ENOENT
   raise 'Configuration file not found! Please copy example.config.yml to config.yml and try again.'
 end
-vconfig = YAML::load_file("#{dir}/config.yml")
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = vconfig['vagrant_hostname']
-  if vconfig['vagrant_ip'] == "0.0.0.0" && Vagrant.has_plugin?("vagrant-auto_network")
-    config.vm.network :private_network, :ip => vconfig['vagrant_ip'], :auto_network => true
+  if vconfig['vagrant_ip'] == '0.0.0.0' && Vagrant.has_plugin?('vagrant-auto_network')
+    config.vm.network :private_network, ip: vconfig['vagrant_ip'], auto_network: true
   else
     config.vm.network :private_network, ip: vconfig['vagrant_ip']
   end
 
-  if !vconfig['vagrant_public_ip'].empty? && vconfig['vagrant_public_ip'] == "0.0.0.0"
+  if vconfig['vagrant_public_ip'] == '0.0.0.0'
     config.vm.network :public_network
   elsif !vconfig['vagrant_public_ip'].empty?
     config.vm.network :public_network, ip: vconfig['vagrant_public_ip']
@@ -42,30 +44,30 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = vconfig['vagrant_box']
 
   # If hostsupdater plugin is installed, add all server names as aliases.
-  if Vagrant.has_plugin?("vagrant-hostsupdater")
+  if Vagrant.has_plugin?('vagrant-hostsupdater')
     config.hostsupdater.aliases = []
     # Add all hosts that aren't defined as Ansible vars.
-    if vconfig['drupalvm_webserver'] == "apache"
-      for host in vconfig['apache_vhosts']
-        unless host['servername'].include? "{{"
+    if vconfig['drupalvm_webserver'] == 'apache'
+      vconfig['apache_vhosts'].each do |host|
+        unless host['servername'].include? '{{'
           config.hostsupdater.aliases.push(host['servername'])
         end
       end
     else
-      for host in vconfig['nginx_hosts']
-        unless host['server_name'].include? "{{"
+      vconfig['nginx_hosts'].each do |host|
+        unless host['server_name'].include? '{{'
           config.hostsupdater.aliases.push(host['server_name'])
         end
       end
     end
   end
 
-  for synced_folder in vconfig['vagrant_synced_folders'];
+  vconfig['vagrant_synced_folders'].each do |synced_folder|
     config.vm.synced_folder synced_folder['local_path'], synced_folder['destination'],
       type: synced_folder['type'],
-      rsync__auto: "true",
+      rsync__auto: 'true',
       rsync__exclude: synced_folder['excluded_paths'],
-      rsync__args: ["--verbose", "--archive", "--delete", "-z", "--chmod=ugo=rwX"],
+      rsync__args: ['--verbose', '--archive', '--delete', '-z', '--chmod=ugo=rwX'],
       id: synced_folder['id'],
       create: synced_folder.include?('create') ? synced_folder['create'] : false,
       mount_options: synced_folder.include?('mount_options') ? synced_folder['mount_options'] : []
@@ -73,26 +75,26 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Provision using Ansible provisioner if Ansible is installed on host.
   if which('ansible-playbook')
-    config.vm.provision "ansible" do |ansible|
+    config.vm.provision 'ansible' do |ansible|
       ansible.playbook = "#{dir}/provisioning/playbook.yml"
       ansible.sudo = true
     end
   # Provision using shell provisioner and JJG-Ansible-Windows otherwise.
   else
-    config.vm.provision "shell" do |sh|
+    config.vm.provision 'shell' do |sh|
       sh.path = "#{dir}/provisioning/JJG-Ansible-Windows/windows.sh"
-      sh.args = "/provisioning/playbook.yml"
+      sh.args = '/provisioning/playbook.yml'
     end
   end
 
   # VMware Fusion.
   config.vm.provider :vmware_fusion do |v, override|
     # HGFS kernel module currently doesn't load correctly for native shares.
-    override.vm.synced_folder ".", "/vagrant", type: 'nfs'
+    override.vm.synced_folder '.', '/vagrant', type: 'nfs'
 
     v.gui = false
-    v.vmx["memsize"] = vconfig['vagrant_memory']
-    v.vmx["numvcpus"] = vconfig['vagrant_cpus']
+    v.vmx['memsize'] = vconfig['vagrant_memory']
+    v.vmx['numvcpus'] = vconfig['vagrant_cpus']
   end
 
   # VirtualBox.
@@ -100,8 +102,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.name = vconfig['vagrant_hostname']
     v.memory = vconfig['vagrant_memory']
     v.cpus = vconfig['vagrant_cpus']
-    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-    v.customize ["modifyvm", :id, "--ioapic", "on"]
+    v.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+    v.customize ['modifyvm', :id, '--ioapic', 'on']
   end
 
   # Parallels.
@@ -113,6 +115,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   # Set the name of the VM. See: http://stackoverflow.com/a/17864388/100134
-  config.vm.define vconfig['vagrant_machine_name'] do |d|
-  end
+  config.vm.define vconfig['vagrant_machine_name']
 end


### PR DESCRIPTION
I ran `rubocop --auto-correct` on Vagrantfile to be more ruby coding style compliant and made some minor style fixes. The `.rubocop.yml` is there to skip two remaining offenses (long lines and [indentation](https://github.com/geerlingguy/drupal-vm/blob/master/Vagrantfile#L65)). 