### PR TITLE
add support for overriding any synced_folder option

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -66,7 +66,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Synced folders.
   for synced_folder in vconfig['vagrant_synced_folders'];
-    config.vm.synced_folder synced_folder['local_path'], synced_folder['destination'],
+    options = {
       type: synced_folder['type'],
       rsync__auto: "true",
       rsync__exclude: synced_folder['excluded_paths'],
@@ -74,6 +74,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       id: synced_folder['id'],
       create: synced_folder.include?('create') ? synced_folder['create'] : false,
       mount_options: synced_folder.include?('mount_options') ? synced_folder['mount_options'] : []
+    }
+    if synced_folder.include?('options_override');
+      options = options.merge(synced_folder['options_override'])
+    end
+    config.vm.synced_folder synced_folder['local_path'], synced_folder['destination'], options
   end
 
   # Allow override of the default synced folder type.

--- a/docs/extras/syncing-folders.md
+++ b/docs/extras/syncing-folders.md
@@ -12,6 +12,30 @@ vagrant_synced_folders:
 
 You can add as many synced folders as you'd like, and you can configure [any type of share](https://docs.vagrantup.com/v2/synced-folders/index.html) supported by Vagrant; just add another item to the list of `vagrant_synced_folders`.
 
+## Options
+
+The synced folder options exposed are `type`, `excluded_paths` (when using rsync), `id`, `create` and `mount_options`. Besides these there are some sane defaults set when using rsync. For example all files synced with rsync will be writable by everyone, thus allowing the web server to create files.
+
+### Overriding defaults
+
+If you feel the need to fine-tune some of the options not exposed, the entire options hash passed to Vagrant can be overriden using `options_override`.
+
+The merge of the default options and `options_override` is shallow, so you can use it to remove flags from eg. `rsync__args`.
+
+One scenario where this might be useful is when you are moving generated code from the virtual machine back to your local machine and you want the files to have appropriate permissions instead of the default 666/777.
+
+```yaml
+options_override:
+  # Disable the default recursive chown so that the files/ folder won't be affected
+  rsync__chown: false
+  rsync__args: [
+    "--verbose", "--archive", "--delete",
+    "--chmod=gu=rwX,o=rX", # 664 for files, 775 for directories
+    "--owner", "--group", # required for the following command
+    "--usermap=*:vagrant", "--groupmap=*:www-data"
+  ]
+```
+
 ## Synced Folder Performance
 
 Using different synced folder mechanisms can have a dramatic impact on your Drupal site's performance. Please read through the following blog posts for a thorough overview of synced folder performance:


### PR DESCRIPTION
I mentioned this earlier in https://github.com/geerlingguy/drupal-vm/issues/189#issuecomment-139809306.

This would allow the user to override any option passed to `config.vm.synced_folders`. By default it would still work exactly as is does now. Currently I'm using these options for most of my projects for better file permissions using rsync (the merge is not deep by choice, so that you can eg remove specific `rsync__args`).

```rb
options_override:
  rsync__chown: false
  rsync__verbose: true
  rsync__args: [
    "--verbose", "--archive", "--delete",
    "--chmod=Dgu=rwx,Do=rx,Fgu=rw,Fo=r", # 664 for files, 775 for directories
    "--owner", "--group", # required for the following command
    "--usermap=*:vagrant", "--groupmap=*:www-data,*:apache",
  ]
```