### PR TITLE
Adding Amazon Web Services Server support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -85,6 +85,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
+  # Amazon Web Services Server
+  if !vconfig['aws_key_id'].empty?
+    config.vm.provider :aws do |aws, override|
+      override.nfs.functional = false
+      aws.access_key_id = vconfig['aws_key_id']
+      aws.secret_access_key = vconfig['aws_secret_access_key']
+      aws.keypair_name = vconfig['aws_key_pair_name']
+      aws.security_groups = vconfig['aws_security_group']
+      aws.ami = vconfig['aws_ami']
+      aws.tags['Name'] = vconfig['aws_tags_name']
+      override.ssh.username = vconfig['override_ssh_username']
+      override.ssh.private_key_path = vconfig['override_ssh_private_key_path']
+    end
+  end
+
   # VMware Fusion.
   config.vm.provider :vmware_fusion do |v, override|
     # HGFS kernel module currently doesn't load correctly for native shares.

--- a/example.config.yml
+++ b/example.config.yml
@@ -34,6 +34,7 @@ aws_key_id: ""
 aws_secret_access_key: ""
 aws_key_pair_name: "KeyPairName_CaSeSeNsItIvE"
 aws_security_group: "Test-security-group-name"
+aws_ami: 'ami-7747d01e'
 aws_tags_name: "Test AWS Vagrant"
 override_ssh_username: "ubuntu"
 override_ssh_private_key_path: 'PATH_TO_YOUR_PEM_FILE'

--- a/example.config.yml
+++ b/example.config.yml
@@ -15,6 +15,29 @@ vagrant_ip: 192.168.88.88
 # See: https://docs.vagrantup.com/v2/networking/public_network.html
 vagrant_public_ip: ""
 
+# If you want to use a Amazon Web Services Server
+# This will remain off unless aws_key_id != ''
+# If you turn this setting on, you must make a 
+# .pem file that points to the path you specify
+# containing the private key of the Amazon Instance.
+# aws_key_id: Retrieved from the users section of AWS
+# aws_secret_access_key: Also retrieved from users sections of AWS
+# aws_key_pair_name: The name of the KeyPair you generated on AWS
+#                    MUST BE EXACT spelling (Caps, Etc).
+# aws_security_group: The group name you want the security to use.
+# aws_tags_name: What you want the AWS tag name to show up as.
+# override_ssh_username: The SSH username. Should be ubuntun 90% of the time.
+# override_ssh_private_key_path: The path to the private key for the keypair
+#                                you created.
+# The ssh username is default to ubuntu
+aws_key_id: ""
+aws_secret_access_key: ""
+aws_key_pair_name: "KeyPairName_CaSeSeNsItIvE"
+aws_security_group: "Test-security-group-name"
+aws_tags_name: "Test AWS Vagrant"
+override_ssh_username: "ubuntu"
+override_ssh_private_key_path: 'PATH_TO_YOUR_PEM_FILE'
+
 # A list of synced folders, with the keys 'local_path', 'destination', and
 # a 'type' of [nfs|rsync|smb] (leave empty for slow native shares). See
 # http://docs.drupalvm.com/en/latest/extras/syncing-folders/ for more info.


### PR DESCRIPTION
We assume that the user has an Ansible version of at least 1.9.4 (May work with an older version, only used the newest one.).

We also assume that the user has an AWS account already, has at least one created user, created a Key Pair (and has the PEM key associated), and has a security group set up.


