### PR TITLE
Clean up and bring docs up to date with latest example configurations

### DIFF
--- a/docs/deployment/drush-make.md
+++ b/docs/deployment/drush-make.md
@@ -1,4 +1,4 @@
-Drupal VM is configured by default to use a Drush make file to build a Drupal site on the VM inside `/var/www/drupal` (in a folder that's synced to your local machine, so you can work with the Drupal codebase either locally or inside the VM).
+Drupal VM is configured by default to use a Drush make file to build a Drupal site on the VM inside `/var/www/drupalvm/drupal` (in a folder that's synced to your local machine, so you can work with the Drupal codebase either locally or inside the VM).
 
 You can use any make file you want, just copy it or symlink it into the root of the Drupal VM folder with the filename `drupal.make.yml`. You can also set a separate path to the makefile using the `drush_makefile_path` variable.
 

--- a/docs/deployment/local-codebase.md
+++ b/docs/deployment/local-codebase.md
@@ -41,4 +41,4 @@ If you have your Drupal site configured to use a special database and/or user/pa
 
 ## Build the VM, import your database
 
-Run `vagrant up` to build the VM with your codebase synced into the proper location. Once the VM is created, you can connect to the MySQL database (see the sidebar topic "MySQL - Connecting to the DB") and import your site's database to the Drupal VM, or use a command like `drush sql-sync` to copy a database from another server.
+Run `vagrant up` to build the VM with your codebase synced into the proper location. Once the VM is created, you can [connect to the MySQL database](../extras/mysql.md) and import your site's database to the Drupal VM, or use a command like `drush sql-sync` to copy a database from another server.

--- a/docs/deployment/local-codebase.md
+++ b/docs/deployment/local-codebase.md
@@ -21,7 +21,7 @@ build_makefile:: false
 install_site: false
 ```
 
-_If you aren't copying back a database, and want to have Drupal VM run `drush si` for your Drupal site, you can leave `install_site` set to `true` and it will run a site install on your Drupal codebase using the `drupal_*` config variables.
+If you aren't copying back a database, and want to have Drupal VM run `drush si` for your Drupal site, you can leave `install_site` set to `true` and it will run a site install on your Drupal codebase using the `drupal_*` config variables.
 
 ## Update `apache_vhosts`
 

--- a/docs/deployment/local-codebase.md
+++ b/docs/deployment/local-codebase.md
@@ -29,8 +29,10 @@ Add your site to `apache_vhosts`, setting the `documentroot` to the same value a
 
 ```yaml
 apache_vhosts:
-  - {servername: "local.my-drupal-site.com", documentroot: "/var/www/my-drupal-site"}
-  - {servername: "local.xhprof.com", documentroot: "/usr/share/php/xhprof_html"}
+  - servername: "local.my-drupal-site.com"
+    documentroot: "/var/www/my-drupal-site"
+    extra_parameters: |
+          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ drupal_core_path }}"
 ```
 
 ## Update MySQL info

--- a/docs/deployment/local-codebase.md
+++ b/docs/deployment/local-codebase.md
@@ -8,7 +8,6 @@ Update the `vagrant_synced_folders` configuration to sync your local Drupal code
 vagrant_synced_folders:
   - local_path: ~/Sites/my-drupal-site
     destination: /var/www/my-drupal-site
-    id: drupal
     type: nfs
 ```
 

--- a/docs/deployment/multisite.md
+++ b/docs/deployment/multisite.md
@@ -1,11 +1,19 @@
-For multisite installations, make the changes outlined in the [Local Drupal codebase](https://github.com/geerlingguy/drupal-vm/wiki/Local-Drupal-codebase) guide, but, using the `apache_vhosts` variable, configure as many domains pointing to the same docroot as you need:
+For multisite installations, make the changes outlined in the [Local Drupal codebase](local-codebase.md) guide, but, using the `apache_vhosts` variable, configure as many domains pointing to the same docroot as you need:
 
 ```yaml
 apache_vhosts:
-  - {servername: "local.my-drupal-site.com", documentroot: "/var/www/my-drupal-site"}
-  - {servername: "local.second-drupal-site.com", documentroot: "/var/www/my-drupal-site"}
-  - {servername: "local.third-drupal-site.com", documentroot: "/var/www/my-drupal-site"}
-  - {servername: "local.xhprof.com", documentroot: "/usr/share/php/xhprof_html"}
+  - servername: "local.my-drupal-site.com"
+    documentroot: "/var/www/my-drupal-site"
+    extra_parameters: |
+          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ drupal_core_path }}"
+  - servername: "local.second-drupal-site.com"
+    documentroot: "/var/www/my-drupal-site"
+    extra_parameters: |
+          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ drupal_core_path }}"
+  - servername: "local.third-drupal-site.com"
+    documentroot: "/var/www/my-drupal-site"
+    extra_parameters: |
+          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ drupal_core_path }}"
 ```
 
 If you need additional databases and database users, add them to the list of `mysql_databases` and `mysql_users`:

--- a/docs/extras/behat.md
+++ b/docs/extras/behat.md
@@ -30,9 +30,9 @@ _You can also include the `behat/*` and `drupal/drupal-extension` directly in yo
 
 ## Setting up Behat for your project
 
-Using the default Drupal site as an example (it's installed in `/var/www/drupal` by default, and is shared to `~/Sites/drupalvm/drupal` on your host machine), the following steps will help you get your first Behat tests up and running!
+Using the default Drupal site as an example (it's installed in `/var/www/drupalvm/drupal` by default, and is shared to `~/Sites/drupalvm/drupal` on your host machine), the following steps will help you get your first Behat tests up and running!
 
-  1. Create a `behat.yml` file inside the docroot of your site (e.g. create this file alongside the rest of the Drupal codebase at `/var/www/drupal/behat.yml`), with the following contents:
+  1. Create a `behat.yml` file inside the docroot of your site (e.g. create this file alongside the rest of the Drupal codebase at `/var/www/drupalvm/drupal/behat.yml`), with the following contents:
 
         default:
           suites:
@@ -55,23 +55,23 @@ Using the default Drupal site as an example (it's installed in `/var/www/drupal`
               blackbox: ~
               api_driver: 'drupal'
               drupal:
-                drupal_root: '/var/www/drupal'
+                drupal_root: '/var/www/drupalvm/drupal'
               region_map:
                 content: "#content"
 
-  2. Log into Drupal VM with `vagrant ssh`, change directory to the Drupal site root (`cd /var/www/drupal`), then run `behat --init` to initialize the `features` folder where you will place test cases.
+  2. Log into Drupal VM with `vagrant ssh`, change directory to the Drupal site root (`cd /var/www/drupalvm/drupal`), then run `behat --init` to initialize the `features` folder where you will place test cases.
   3. From either inside the VM or on the host machine, open up the new `features/web` folder Behat just created. Inside _that_ folder, create `HomeContent.feature` with the following contents:
 
         Feature: Test DrupalContext
           In order to prove the Behat is working correctly in Drupal VM
           As a developer
           I need to run a simple interface test
-        
+
           Scenario: Viewing content in a region
             Given I am on the homepage
             Then I should see "No front page content has been created yet" in the "content"
 
-  4. Now, inside Drupal VM, change directory to `/var/www/drupal` again, and run the command `behat` (which runs all the tests you've created—which should just be one so far).
+  4. Now, inside Drupal VM, change directory to `/var/www/drupalvm/drupal` again, and run the command `behat` (which runs all the tests you've created—which should just be one so far).
 
 If everything was done correctly, you should see:
 

--- a/docs/extras/drupal-console.md
+++ b/docs/extras/drupal-console.md
@@ -5,13 +5,13 @@ Drupal VM will automatically install Drupal Console if you install Drupal 8 or l
 To use Drupal Console with a Drupal 8 site (in this case, using the default configuration that ships with Drupal VM):
 
   1. Log into the VM with `vagrant ssh`.
-  2. Change directory to the Drupal site's document root: `cd /var/www/drupal`.
+  2. Change directory to the Drupal site's document root: `cd /var/www/drupalvm/drupal`.
   3. Use Drupal console (e.g. `drupal cache:rebuild --cache=all`).
 
 You should see an output like:
 
 ```
-vagrant@drupaltest:/var/www/drupal$ drupal cache:rebuild --cache=all
+vagrant@drupalvm:/var/www/drupalvm/drupal$ drupal cache:rebuild --cache=all
 
 [+] Rebuilding cache(s), wait a moment please.
 [+] Done clearing cache(s).

--- a/docs/extras/drupal-console.md
+++ b/docs/extras/drupal-console.md
@@ -1,4 +1,4 @@
-[Drupal Console](http://drupalconsole.com/) is a modern CLI for interacting with Drupal and scaffolding a site. It works only with Drupal 8+, and is built on top of the Symfony Console component.
+[Drupal Console](https://drupalconsole.com/) is a modern CLI for interacting with Drupal and scaffolding a site. It works only with Drupal 8+, and is built on top of the Symfony Console component.
 
 Drupal VM will automatically install Drupal Console if you install Drupal 8 or later in your VM (this is based on the value of the `drupal_major_version` variable inside `config.yml`.
 

--- a/docs/extras/drush.md
+++ b/docs/extras/drush.md
@@ -1,34 +1,34 @@
 If you have Drush installed on your host workstation, and would like to interact with a Drupal site running inside Drupal VM, there are drush aliases automatically created by Drupal VM for each of the virtual hosts you have configured.
 
-With the example configuration, you can manage the example Drupal site using the Drush alias `@drupaltest.dev`. For example, to check if Drush can connect to the site in Drupal VM, run:
+With the example configuration, you can manage the example Drupal site using the Drush alias `@drupalvm.dev`. For example, to check if Drush can connect to the site in Drupal VM, run:
 
 ```
-$ drush @drupaltest.dev status
- Drupal version         :  8.0.0-dev                                                                                    
- Site URI               :  drupaltest.dev                                                                               
- Database driver        :  mysql                                                                                        
- Database hostname      :  localhost                                                                                    
- Database port          :                                                                                               
- Database username      :  drupal                                                                                       
- Database name          :  drupal                                                                                       
- Database               :  Connected                                                                                    
- Drupal bootstrap       :  Successful                                                                                   
- Drupal user            :  Anonymous                                                                                    
- Default theme          :  bartik                                                                                       
- Administration theme   :  seven                                                                                        
- PHP executable         :  /usr/bin/php                                                                                 
- PHP configuration      :  /etc/php5/cli/php.ini                                                                        
- PHP OS                 :  Linux                                                                                        
- Drush script           :  /usr/local/share/drush/drush.php                                                             
- Drush version          :  7.0-dev                                                                                      
- Drush temp directory   :  /tmp                                                                                         
- Drush configuration    :                                                                                               
- Drush alias files      :                                                                                               
- Drupal root            :  /var/www/drupal                                                                              
- Site path              :  sites/default                                                                                
- File directory path    :  sites/default/files                                                                          
- Temporary file         :  /tmp                                                                                         
- directory path                                                                                                         
+$ drush @drupalvm.dev status
+ Drupal version         :  8.0.0-dev
+ Site URI               :  drupalvm.dev
+ Database driver        :  mysql
+ Database hostname      :  localhost
+ Database port          :
+ Database username      :  drupal
+ Database name          :  drupal
+ Database               :  Connected
+ Drupal bootstrap       :  Successful
+ Drupal user            :  Anonymous
+ Default theme          :  bartik
+ Administration theme   :  seven
+ PHP executable         :  /usr/bin/php
+ PHP configuration      :  /etc/php5/cli/php.ini
+ PHP OS                 :  Linux
+ Drush script           :  /usr/local/share/drush/drush.php
+ Drush version          :  7.0-dev
+ Drush temp directory   :  /tmp
+ Drush configuration    :
+ Drush alias files      :
+ Drupal root            :  /var/www/drupalvm/drupal
+ Site path              :  sites/default
+ File directory path    :  sites/default/files
+ Temporary file         :  /tmp
+ directory path
  Active config path     :  [...]
  Staging config path    :  [...]
 ```

--- a/docs/extras/mailhog.md
+++ b/docs/extras/mailhog.md
@@ -1,3 +1,3 @@
-By default, Drupal VM redirects all PHP emails to [MailHog](https://github.com/mailhog/MailHog) (instead of sending them to the outside world). You can access the MailHog UI at `http://drupaltest.dev:8025/` (or whatever domain you have configured in `config.yml`).
+By default, Drupal VM redirects all PHP emails to [MailHog](https://github.com/mailhog/MailHog) (instead of sending them to the outside world). You can access the MailHog UI at `http://drupalvm.dev:8025/` (or whatever domain you have configured in `config.yml`).
 
 You can override the default behavior of redirecting email to MailHog by editing or removing the `php_sendmail_path` inside `config.yml`, and you can choose to not install MailHog at all by removing it from `installed_extras` in `config.yml`.

--- a/docs/extras/nodejs.md
+++ b/docs/extras/nodejs.md
@@ -4,7 +4,7 @@ Drupal VM includes built-in support for Node.js—all you need to do is make sur
 
 ## Choosing a version of Node.js
 
-You can choose a version of Node.js to install using the `nodejs_version` variable in `config.yml`. See the `geerlingguy.nodejs` role documentation for all the currently-available versions for your OS.
+You can choose a version of Node.js to install using the `nodejs_version` variable in `config.yml`. See the [`geerlingguy.nodejs` Ansible role's README](https://github.com/geerlingguy/ansible-role-nodejs#readme) for all the currently-available versions for your OS.
 
 ```yaml
 nodejs_version: "0.12"

--- a/docs/extras/solr.md
+++ b/docs/extras/solr.md
@@ -10,7 +10,12 @@ This will connect to the default search core (`collection1`) set up by Solr. If 
 
 ## Configuring the Solr search core for Drupal
 
-Before Drupal content can be indexed correctly into Apache Solr, you will need to copy the Drupal Apache Solr Search or Search API Apache Solr configuration into place, and restart Apache Solr. This process will soon be automated, but for now, please perform the steps outlined in step 5 in this blog post (which should work with Drupal VM): [Solr for Drupal Developers, Part 3: Testing Solr locally](http://www.midwesternmac.com/blogs/jeff-geerling/solr-drupal-developers-part-3).
+Before Drupal content can be indexed correctly into Apache Solr, you will need to copy the Drupal Apache Solr Search or Search API Apache Solr configuration into place, and restart Apache Solr. Drupal VM comes with an example post provision script for automating this. Simply add it to `post_provision_scripts`:
+
+```yaml
+post_provision_scripts:
+ - "../examples/scripts/configure-solr.sh"
+```
 
 ## Extra Solr configuration
 

--- a/docs/extras/solr.md
+++ b/docs/extras/solr.md
@@ -6,7 +6,7 @@ The URL to connect to the local solr server (assuming you're using the default `
 
     http://localhost:8983/solr/collection1
 
-This will connect to the default search core (`collection1`) set up by Solr. If you are using a multisite installation and want to have a search core per Drupal site, you can add more cores through Apache Solr's admin interface (visit `http://drupaltest.dev:8983/solr/`), then connect to each core by adding the core name to the end of the above URL (e.g. `core2` would be `http://localhost:8983/solr/core2`).
+This will connect to the default search core (`collection1`) set up by Solr. If you are using a multisite installation and want to have a search core per Drupal site, you can add more cores through Apache Solr's admin interface (visit `http://drupalvm.dev:8983/solr/`), then connect to each core by adding the core name to the end of the above URL (e.g. `core2` would be `http://localhost:8983/solr/core2`).
 
 ## Configuring the Solr search core for Drupal
 

--- a/docs/extras/syncing-folders.md
+++ b/docs/extras/syncing-folders.md
@@ -40,7 +40,7 @@ options_override:
 Using different synced folder mechanisms can have a dramatic impact on your Drupal site's performance. Please read through the following blog posts for a thorough overview of synced folder performance:
 
   - [Comparing filesystem performance in Virtual Machines](http://mitchellh.com/comparing-filesystem-performance-in-virtual-machines)
-  - [NFS, rsync, and shared folder performance in Vagrant VMs](http://www.midwesternmac.com/blogs/jeff-geerling/nfs-rsync-and-shared-folder)
+  - [NFS, rsync, and shared folder performance in Vagrant VMs](http://www.jeffgeerling.com/blogs/jeff-geerling/nfs-rsync-and-shared-folder)
 
 Generally speaking:
 

--- a/docs/extras/syncing-folders.md
+++ b/docs/extras/syncing-folders.md
@@ -1,16 +1,15 @@
-You can share folders between your host computer and the VM in a variety of ways; the most commonly-used method is an NFS share. If you use Windows and encounter any problems with NFS, try switching to `smb`. The `example.config.yml` file contains an example `nfs` share that would sync the folder `~/Sites/drupalvm` on your host into the `/var/www` folder on Drupal VM.
+You can share folders between your host computer and the VM in a variety of ways; the most commonly-used method is an NFS share. If you use Windows and encounter any problems with NFS, try switching to `smb`. The `example.config.yml` file contains an example `nfs` share that would sync the folder `~/Sites/drupalvm` on your host into the `/var/www/drupalvm` folder on Drupal VM.
 
 If you want to use a different synced folder method (e.g. `smb`), you can change `type` to:
 
 ```yaml
 vagrant_synced_folders:
   - local_path: ~/Sites/drupalvm
-    destination: /var/www
-    id: drupal
+    destination: /var/www/drupalvm
     type: smb
 ```
 
-You can add as many synced folders as you'd like, and you can configure [any type of share](https://docs.vagrantup.com/v2/synced-folders/index.html) supported by Vagrant; just add another item to the list of `vagrant_synced_folders`.
+You can add as many synced folders as you'd like, and you can configure [any type of share](https://www.vagrantup.com/docs/synced-folders/index.html) supported by Vagrant; just add another item to the list of `vagrant_synced_folders`.
 
 ## Options
 
@@ -55,8 +54,7 @@ If you are using rsync, it is advised to exclude certain directories so that the
 ```yaml
 vagrant_synced_folders:
   - local_path: ~/Sites/drupalvm/drupal
-    destination: /var/www
-    id: drupal
+    destination: /var/www/drupalvm
     type: rsync
     excluded_paths:
       - drupal/private
@@ -79,7 +77,6 @@ You can use a native synced folder, which should work pretty flawlessly on any p
 vagrant_synced_folders:
   - local_path: docroot
     destination: /var/www/docroot
-    id: drupal
     type: ""
     create: true
 ```
@@ -103,12 +100,6 @@ mount_options: ["dmode=775,fmode=664"]
 ```
 
 See [this issue](https://github.com/geerlingguy/drupal-vm/issues/66) for more details.
-
-### VirtualBox Symbolic Links
-
-When using native VirtualBox shares, VirtualBox does not allow guest VMs to create symbolic links on synced folders for security reasons. On CentOS this prevents apache from installing since it will try to make a symlink inside `/var/www/` You can change the Drupal synced_folder to `/var/www/drupal` and the `drupal_core_path` to `/var/www/drupal/docroot` to work around this.
-
-There are many other potential [solutions](https://www.google.com/search?q=SharedFoldersEnableSymlinksCreate) available on the Internet.
 
 ### Other NFS-related errors
 

--- a/docs/other/cloning-with-newd.md
+++ b/docs/other/cloning-with-newd.md
@@ -10,6 +10,6 @@ $ newd 7 test-fieldformatter
 $ newd 8 drupal8test
 ```
 
-The source code for this new bash function (you could add it to your own `.bash_profile` or `.profile`) is located here: https://gist.github.com/rgoodie/9966f30b404a4daa59e1
+The source code for this new bash function (you could add it to your own `.bash_profile` or `.profile`) is located [in this gist](https://gist.github.com/rgoodie/9966f30b404a4daa59e1).
 
 Do you have your own wrapper script or other helpers to help you manage instances of Drupal VM? Please share it on this page!

--- a/docs/other/cloning-with-newd.md
+++ b/docs/other/cloning-with-newd.md
@@ -1,4 +1,4 @@
-@rgoodie created a function called `newd` that clones this repo, uses `sed` to change configuration to Drupal 7 if desired, renames the VM to something other than drupaltest.dev, and kicks off `vagrant up`.
+[@rgoodie](https://github.com/rgoodie) created a function called `newd` that clones this repo, uses `sed` to change configuration to Drupal 7 if desired, renames the VM to something other than drupalvm.dev, and kicks off `vagrant up`.
 
 Example:
 

--- a/docs/other/linux.md
+++ b/docs/other/linux.md
@@ -57,7 +57,7 @@ If you get this message, then it's likely that either NFS isn't running correctl
 
   1. On Ubuntu, if you get a message like `It appears your machine doesn't support NFS`, run `sudo apt-get install -y nfs-server`.
   2. Install the `vagrant-vbguest` plugin, which will make sure you are running the latest version of the VirualBox Guest Additions inside the VM (this can solve many different problems!).
-  3. Make sure the `vboxnet` interfaces are not being blocked by your system firewall. For Fedora (and many flavors of Linux), check out this guide for more: [Get Vagrant's NFS working under Fedora 20](http://blog.bak1an.site/blog/2014/03/23/fedora-vagrant-nfs/).
+  3. Make sure the `vboxnet` interfaces are not being blocked by your system firewall. For Fedora (and many flavors of Linux), check out this guide for more: [Get Vagrant's NFS working under Fedora 20](https://web.archive.org/web/20150706105420/http://blog.bak1an.so/blog/2014/03/23/fedora-vagrant-nfs/).
   4. Add `mount_options: ['vers=3']` to your synced folder definition in config.yml after the other options like `local_path`, `destination`, and `type`.
 
 After attempting any of the above fixes, run `vagrant reload --provision` to restart the VM and attempt mounting the synced folder again, or `vagrant destroy -f && vagrant up` to rebuild the VM from scratch.

--- a/docs/other/php-7.md
+++ b/docs/other/php-7.md
@@ -34,6 +34,6 @@ You can also build from source using the same/included `geerlingguy.php` Ansible
 
 Remi's RPM repository is included with Drupal VM, and you can make the following changes to use it to install PHP 7:
 
-  1. Make sure you've followed the directions for switching to CentOS 7 in the [use a different base OS](https://github.com/geerlingguy/drupal-vm/wiki/Using-Different-Base-OSes) guide.
+  1. Make sure you've followed the directions for switching to CentOS 7 in the [use a different base OS](base-os.md) guide.
   2. Change `php_version` inside `config.yml` to `"7.0"`.
   3. Comment out `xhprof`, `xdebug`, `redis` and `memcached` from the `installed_extras` list, as these extensions are not yet supported for PHP 7 (as of late 2015).

--- a/docs/other/webservers.md
+++ b/docs/other/webservers.md
@@ -8,10 +8,10 @@ Because the webservers are configured somewhat differently, there are a few thin
 
 You have complete control over all aspects of Apache VirtualHosts using the `apache_vhosts` configuration. A few simple examples are shown in `example.config.yml`, but this configuration can be much more complex.
 
-See the examples included in the [`geerlingguy.apache`](https://github.com/geerlingguy/ansible-role-apache) Ansible role's README for more info, as well as many other variables you can override to configure Apache exactly how you like it.
+See the examples included in the [`geerlingguy.apache` Ansible role's README](https://github.com/geerlingguy/ansible-role-apache#readme) for more info, as well as many other variables you can override to configure Apache exactly how you like it.
 
 ## Using Nginx
 
 Because Nginx server directives behave a little differently than Apache's VirtualHosts, Drupal VM includes a custom Drupal-optimized Nginx server block configuration, and you can control all the servers ('virtual hosts') Nginx will run using the `nginx_hosts` configuration. A few simple examples are shown in `example.config.yml`, but you have some extra flexibility if you need it. See the `nginx-vhost.conf.j2` template for more information.
 
-Also, see the examples included in the [`geerlingguy.nginx`](https://github.com/geerlingguy/ansible-role-nginx) Ansible role's README for more info, as well as many other variables you can override to configure Nginx exactly how you like it.
+Also, see the examples included in the [`geerlingguy.nginx` Ansible role's README](https://github.com/geerlingguy/ansible-role-nginx#readme) for more info, as well as many other variables you can override to configure Nginx exactly how you like it.

--- a/docs/other/windows.md
+++ b/docs/other/windows.md
@@ -29,10 +29,6 @@ You should probably disable Git's `fileMode` option inside the VM and on your ho
 
     git config core.fileMode false
 
-### Long Paths
-
-Creating long paths inside a shared folder will fail if the length exceeds 260 characters. This usually happens when using npm. This should be solved in Vagrant 1.7.3, but if you're running an older version, you can manually make the changes here: https://github.com/mitchellh/vagrant/pull/5495/files
-
 ### NFS
 
 You can use the [vagrant-winnfsd](https://github.com/GM-Alex/vagrant-winnfsd) plugin to get NFS support on windows. Be aware that there are multiple issues logged against both the plugin and the winnfsd project, so no guarantees.


### PR DESCRIPTION
Worth reviewing as I removed some docs that I figured wasn't supported anymore (mentioned in commit messages):
- Long paths on Windows with Vagrant 1.7
- Symbolic links on CentOS 6 as we dont symlink the docroot anymore.