### PR TITLE
[WIP] Issue #320: add a dashboard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
       MAKEFILE: example.drupal.make.yml
       HOSTNAME: drupalvm.dev
       MACHINE_NAME: drupalvm
+      IP: 192.168.88.88
   matrix:
     - distribution: centos
       version: 6
@@ -93,6 +94,12 @@ script:
     | grep -q '<title>MailHog'
     && (echo 'MailHog install pass' && exit 0)
     || (echo 'MailHog install fail' && exit 1)
+
+  - >
+    sudo docker exec "$(cat ${container_id})" curl -s --header Host:${IP} localhost
+    | grep -q "<li>${HOSTNAME} ${IP}</li>"
+    && (echo 'Dashboard install pass' && exit 0)
+    || (echo 'Dashboard install fail' && exit 1)
 
   - >
     sudo docker exec "$(cat ${container_id})" drush @${MACHINE_NAME}.${HOSTNAME} status

--- a/example.config.yml
+++ b/example.config.yml
@@ -97,6 +97,9 @@ apache_vhosts:
     extra_parameters: |
           ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ pimpmylog_install_dir }}"
 
+  - servername: "{{ vagrant_ip }}"
+    documentroot: "{{ dashboard_install_dir }}"
+
 apache_remove_default_vhost: true
 apache_mods_enabled:
   - expires.load
@@ -124,6 +127,9 @@ nginx_hosts:
   - server_name: "pimpmylog.{{ vagrant_hostname }}"
     root: "{{ pimpmylog_install_dir }}"
     is_php: true
+
+  - server_name: "{{ vagrant_ip }}"
+    root: "{{ dashboard_install_dir }}"
 
 nginx_remove_default_vhost: true
 
@@ -253,4 +259,5 @@ solr_xmx: "128M"
 selenium_version: 2.46.0
 
 # Other configuration.
+dashboard_install_dir: /var/www/dashboard
 known_hosts_path: ~/.ssh/known_hosts

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -75,6 +75,7 @@
 
     - include: tasks/drush-aliases.yml
     - include: tasks/cron.yml
+    - include: tasks/dashboard.yml
 
     - name: Run configured post-provision shell scripts.
       script: "{{ item }}"

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -3,6 +3,7 @@
   become: yes
 
   vars_files:
+    - vars/main.yml
     - ../config.yml
 
   pre_tasks:
@@ -75,7 +76,9 @@
 
     - include: tasks/drush-aliases.yml
     - include: tasks/cron.yml
+
     - include: tasks/dashboard.yml
+      when: dashboard_install_dir is defined
 
     - name: Run configured post-provision shell scripts.
       script: "{{ item }}"

--- a/provisioning/tasks/dashboard.yml
+++ b/provisioning/tasks/dashboard.yml
@@ -1,0 +1,11 @@
+- name: Ensure the dashboard directory exists
+  file:
+    path: "{{ dashboard_install_dir }}"
+    state: directory
+    mode: 0755
+
+- name: Copy dashboard page into place.
+  template:
+    src: ../templates/dashboard.html.j2
+    dest: "{{ dashboard_install_dir }}/index.html"
+    mode: 0644

--- a/provisioning/templates/dashboard.html.j2
+++ b/provisioning/templates/dashboard.html.j2
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+  <head>
+    <title>Drupal VM</title>
+    <meta charset="utf-8">
+    <style>
+      .section-host {
+        font-family: monospace;
+        list-style-type: none;
+        padding: 0;
+        margin: 0;
+      }
+      /* minor fallback styling for when loaded without an internet connection */
+      .panel, .jumbotron, .well {
+        margin-bottom: 20px;
+      }
+      td, th {
+        padding: 8px;
+      }
+    </style>
+  </head>
+  <body>
+    {%
+      set devtool_docroots = [
+        adminer_install_dir if 'adminer' in installed_extras else '',
+        php_xhprof_html_dir if 'xhprof' in installed_extras else '',
+        pimpmylog_install_dir if 'pimpmylog' in installed_extras else '',
+        dashboard_install_dir
+      ]
+    %}
+
+    {# Returns the hosts server name based on the document root #}
+    {%- macro getServernameFromDocroot(path) -%}
+      {%- if drupalvm_webserver == 'apache' -%}
+        {%- for host in apache_vhosts -%}
+          {%- if host.documentroot == path -%}
+            {{ host.servername }}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- elif drupalvm_webserver == 'nginx' -%}
+        {%- for host in nginx_hosts -%}
+          {%- if host.root == path -%}
+            {{ host.server_name }}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- endif -%}
+    {%- endmacro -%}
+
+    {%- macro printSite(servername, docroot) -%}
+      {%- if docroot not in devtool_docroots -%}
+        <tr>
+          <td><a href="http://{{ servername }}">{{ servername }}</a></td>
+          <td><code>{{ docroot }}</code></td>
+        {% if configure_local_drush_aliases %}
+          <td><code>drush @{{ vagrant_machine_name }}.{{ servername }}</code></td>
+        {% endif %}
+        </tr>
+      {% endif %}
+    {%- endmacro %}
+
+    {%- macro sectionHost() -%}
+      <ul class="section-host">
+        {% if drupalvm_webserver == 'apache' -%}
+          {%- for host in apache_vhosts -%}
+            {%- if host.documentroot != dashboard_install_dir -%}
+              <li>{{ host.servername }} {{ vagrant_ip }}</li>
+            {%- endif -%}
+            {% if host.serveralias is defined -%}
+              {%- for alias in host.serveralias.split() -%}
+                <li>{{ alias }} {{ vagrant_ip }}</li>
+              {%- endfor -%}
+            {%- endif %}
+          {%- endfor -%}
+        {%- elif drupalvm_webserver == 'nginx' -%}
+          {%- for host in nginx_hosts -%}
+            {%- if host.root != dashboard_install_dir -%}
+              <li>{{ host.server_name }} {{ vagrant_ip }}</li>
+            {%- endif -%}
+          {%- endfor -%}
+        {%- endif %}
+      </ul>
+    {%- endmacro -%}
+
+    {%- macro sectionSiteList() -%}
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Hostname</th>
+            <th>Document Root</th>
+            {% if configure_local_drush_aliases -%}
+              <th>Drush alias</th>
+            {%- endif %}
+        </thead>
+        <tbody>
+          {% if drupalvm_webserver == 'apache' -%}
+            {%- for host in apache_vhosts -%}
+              {{ printSite(host.servername, host.documentroot) }}
+            {%- endfor -%}
+          {%- elif drupalvm_webserver == 'nginx' -%}
+            {%- for host in nginx_hosts -%}
+              {{ printSite(host.server_name, host.root) }}
+            {%- endfor -%}
+          {%- endif %}
+        </tbody>
+      </table>
+    {%- endmacro -%}
+
+    {%- macro sectionDevelopmentTools() -%}
+      <table class="table">
+        {% if 'adminer' in installed_extras -%}
+          {% set servername %}{{ getServernameFromDocroot(adminer_install_dir) }}/{{ adminer_install_filename }}{% endset %}
+          {%- if servername != "/{{ adminer_install_filename }}" -%}
+            <tr>
+              <th>Adminer</th>
+              <td><a href="http://{{ servername }}">{{ servername }}</a></td>
+              <td class="text-right">
+                <a href="http://{{ servername }}" class="btn btn-success btn-xs" role="button">Open</a>
+                <a href="http://docs.drupalvm.com/en/latest/extras/mysql/#connect-using-adminer" target="_blank" class="btn btn-info btn-xs" role="button">Documentation</a>
+              </td>
+            </tr>
+          {%- endif -%}
+        {%- endif %}
+        {% if 'mailhog' in installed_extras -%}
+          {% set servername %}{{ vagrant_hostname }}:8025{% endset %}
+          {%- if servername != ":8025" -%}
+            <tr>
+              <th>MailHog</th>
+              <td><a href="http://{{ servername }}">{{ servername }}</a></td>
+              <td class="text-right">
+                <a href="http://{{ servername }}" class="btn btn-success btn-xs" role="button">Open</a>
+                <a href="http://docs.drupalvm.com/en/latest/extras/mailhog/" target="_blank" class="btn btn-info btn-xs" role="button">Documentation</a>
+              </td>
+            </tr>
+          {%- endif -%}
+        {%- endif %}
+        {% if 'pimpmylog' in installed_extras -%}
+          {% set servername = getServernameFromDocroot(pimpmylog_install_dir) %}
+          {%- if servername -%}
+            <tr>
+              <th>PimpMyLog</th>
+              <td><a href="http://{{ servername }}">{{ servername }}</a></td>
+              <td class="text-right">
+                <a href="http://{{ servername }}" class="btn btn-success btn-xs" role="button">Open</a>
+                <a href="http://docs.drupalvm.com/en/latest/extras/pimpmylog/" target="_blank" class="btn btn-info btn-xs" role="button">Documentation</a>
+              </td>
+            </tr>
+          {%- endif -%}
+        {%- endif %}
+        {% if 'solr' in installed_extras -%}
+          {% set servername %}{{ vagrant_hostname }}:{{ solr_port }}/solr/{% endset %}
+          <tr>
+            <th>Solr</th>
+            <td><a href="http://{{ servername }}">{{ servername }}</a></td>
+            <td class="text-right">
+              <a href="http://{{ servername }}" class="btn btn-success btn-xs" role="button">Open</a>
+              <a href="http://docs.drupalvm.com/en/latest/extras/solr/" target="_blank" class="btn btn-info btn-xs" role="button">Documentation</a>
+            </td>
+          </tr>
+        {%- endif %}
+        {% if 'xhprof' in installed_extras -%}
+          {% set servername = getServernameFromDocroot(php_xhprof_html_dir) %}
+          {%- if servername -%}
+            <tr>
+              <th>XHProf</th>
+              <td><a href="http://{{ servername }}">{{ servername }}</a></td>
+              <td class="text-right">
+                <a href="http://{{ servername }}" class="btn btn-success btn-xs" role="button">Open</a>
+                <a href="http://docs.drupalvm.com/en/latest/extras/xhprof/" target="_blank" class="btn btn-info btn-xs" role="button">Documentation</a>
+              </td>
+            </tr>
+          {%- endif -%}
+        {%- endif %}
+      </table>
+    {%- endmacro -%}
+
+    {%- macro sectionDatabaseConnection() -%}
+      <table class="table">
+        <tr>
+          <th>MySQL Hostname</th>
+          <td><code>127.0.0.1</code></td>
+        </tr>
+        <tr>
+          <th>MySQL Port</th>
+          <td><code>{{ mysql_port }}</code></td>
+        </tr>
+        <tr>
+          <th>MySQL Username</th>
+          <td><code>{{ mysql_root_username }}</code></td>
+        </tr>
+        <tr>
+          <th>MySQL Password</th>
+          <td><code>{{ mysql_root_password }}</code></td>
+        </tr>
+        <tr>
+          <th>SSH Hostname</th>
+          <td><code>{{ vagrant_ip }}</code></td>
+        </tr>
+        <tr>
+          <th>SSH Username</th>
+          <td><code>{{ vagrant_user }}</code></td>
+        </tr>
+        <tr>
+          <th>SSH Private Key</th>
+          <td><code>~/.vagrant.d/insecure_private_key</code></td>
+        </tr>
+      </table>
+    {%- endmacro -%}
+
+    {%- macro sectionDatabaseList() -%}
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Database name</th>
+            {% if 'adminer' in installed_extras -%}
+              <th></th>
+            {%- endif %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for database in mysql_databases -%}
+            <tr>
+              <td><code>{{ database.name }}</code></td>
+              {% if 'adminer' in installed_extras -%}
+              <td>
+                <a href="http://{{ getServernameFromDocroot(adminer_install_dir) }}/{{ adminer_install_filename }}?username={{ mysql_root_username }}&db={{ database.name }}" class="btn btn-success btn-xs" role="button">Adminer</a>
+              </td>
+              {%- endif %}
+            </tr>
+          {%- endfor %}
+        </tbody>
+      </table>
+    {%- endmacro -%}
+
+    {%- macro sectionDatabaseUserList() -%}
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Username</th>
+            <th>Password</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for user in mysql_users -%}
+            <tr>
+              <td><code>{{ user.name }}</code></td>
+              <td><code>{{ user.password }}</code></td>
+            </tr>
+          {%- endfor %}
+        </tbody>
+      </table>
+    {%- endmacro -%}
+
+    <div class="container">
+
+      <div class="row">
+        <div class="col-md-12">
+          <section class="jumbotron">
+            <div class="row">
+              <div class="col-md-7 text-center">
+                <img src="http://docs.drupalvm.com/en/latest/images/drupal-vm-logo.png" alt="Drupal VM" title="Welcome to Drupal VM">
+                <p><a href="https://github.com/geerlingguy/drupal-vm">Drupal VM</a> is a VM for local Drupal development, built with Vagrant + Ansible.</p>
+                <p><a class="btn btn-primary btn-lg" href="http://docs.drupalvm.com/en/latest/" role="button">Read the documentation</a></p>
+              </div>
+
+              <div class="col-md-5">
+                <h5>/etc/hosts</h5>
+                <section class="well small">
+                  {{ sectionHost() }}
+                </section>
+                <small>Unless you're using the <a href="https://github.com/cogitatio/vagrant-hostsupdater" target="_blank">vagrant-hostsupdater</a> plugin, add the following to your host machine's hosts file.</small>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-md-7">
+
+          <section class="panel panel-default">
+            <div class="panel-heading">Your sites</div>
+            <div class="panel-body">
+              {{ sectionSiteList() }}
+            </div>
+          </section>
+
+          <section class="panel panel-default">
+            <div class="panel-heading">Development tools</div>
+            <div class="panel-body">
+              {{ sectionDevelopmentTools() }}
+            </div>
+          </section>
+        </div>
+
+        <div class="col-md-5">
+          <section class="panel panel-default">
+            <div class="panel-heading">MySQL connection information</div>
+            <div class="panel-body">
+              {{ sectionDatabaseConnection() }}
+            </div>
+          </section>
+
+          <section class="panel panel-default">
+            <div class="panel-heading">Databases</div>
+            <div class="panel-body">
+              {{ sectionDatabaseList() }}
+
+              {{ sectionDatabaseUserList() }}
+            </div>
+          </section>
+        </div>
+      </div>
+
+    </div>
+
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+  </body>
+</html>

--- a/provisioning/templates/dashboard.html.j2
+++ b/provisioning/templates/dashboard.html.j2
@@ -19,15 +19,6 @@
     </style>
   </head>
   <body>
-    {%
-      set devtool_docroots = [
-        adminer_install_dir if 'adminer' in installed_extras else '',
-        php_xhprof_html_dir if 'xhprof' in installed_extras else '',
-        pimpmylog_install_dir if 'pimpmylog' in installed_extras else '',
-        dashboard_install_dir
-      ]
-    %}
-
     {# Returns the hosts server name based on the document root #}
     {%- macro getServernameFromDocroot(path) -%}
       {%- if drupalvm_webserver == 'apache' -%}
@@ -46,7 +37,7 @@
     {%- endmacro -%}
 
     {%- macro printSite(servername, docroot) -%}
-      {%- if docroot not in devtool_docroots -%}
+      {%- if docroot not in _devtool_docroots -%}
         <tr>
           <td><a href="http://{{ servername }}">{{ servername }}</a></td>
           <td><code>{{ docroot }}</code></td>

--- a/provisioning/templates/dashboard.html.j2
+++ b/provisioning/templates/dashboard.html.j2
@@ -107,63 +107,63 @@
     {%- macro sectionDevelopmentTools() -%}
       <table class="table">
         {% if 'adminer' in installed_extras -%}
-          {% set servername %}{{ getServernameFromDocroot(adminer_install_dir) }}/{{ adminer_install_filename }}{% endset %}
-          {%- if servername != "/{{ adminer_install_filename }}" -%}
+          {% macro servername() %}{{ getServernameFromDocroot(adminer_install_dir) }}/{{ adminer_install_filename }}{% endmacro %}
+          {%- if servername() != "/{{ adminer_install_filename }}" -%}
             <tr>
               <th>Adminer</th>
-              <td><a href="http://{{ servername }}">{{ servername }}</a></td>
+              <td><a href="http://{{ servername() }}">{{ servername() }}</a></td>
               <td class="text-right">
-                <a href="http://{{ servername }}" class="btn btn-success btn-xs" role="button">Open</a>
+                <a href="http://{{ servername() }}" class="btn btn-success btn-xs" role="button">Open</a>
                 <a href="http://docs.drupalvm.com/en/latest/extras/mysql/#connect-using-adminer" target="_blank" class="btn btn-info btn-xs" role="button">Documentation</a>
               </td>
             </tr>
           {%- endif -%}
         {%- endif %}
         {% if 'mailhog' in installed_extras -%}
-          {% set servername %}{{ vagrant_hostname }}:8025{% endset %}
-          {%- if servername != ":8025" -%}
+          {% macro servername() %}{{ vagrant_hostname }}:8025{% endmacro %}
+          {%- if servername() != ":8025" -%}
             <tr>
               <th>MailHog</th>
-              <td><a href="http://{{ servername }}">{{ servername }}</a></td>
+              <td><a href="http://{{ servername() }}">{{ servername() }}</a></td>
               <td class="text-right">
-                <a href="http://{{ servername }}" class="btn btn-success btn-xs" role="button">Open</a>
+                <a href="http://{{ servername() }}" class="btn btn-success btn-xs" role="button">Open</a>
                 <a href="http://docs.drupalvm.com/en/latest/extras/mailhog/" target="_blank" class="btn btn-info btn-xs" role="button">Documentation</a>
               </td>
             </tr>
           {%- endif -%}
         {%- endif %}
         {% if 'pimpmylog' in installed_extras -%}
-          {% set servername = getServernameFromDocroot(pimpmylog_install_dir) %}
-          {%- if servername -%}
+          {% macro servername() %}{{ getServernameFromDocroot(pimpmylog_install_dir) }}{% endmacro %}
+          {%- if servername() -%}
             <tr>
               <th>PimpMyLog</th>
-              <td><a href="http://{{ servername }}">{{ servername }}</a></td>
+              <td><a href="http://{{ servername() }}">{{ servername() }}</a></td>
               <td class="text-right">
-                <a href="http://{{ servername }}" class="btn btn-success btn-xs" role="button">Open</a>
+                <a href="http://{{ servername() }}" class="btn btn-success btn-xs" role="button">Open</a>
                 <a href="http://docs.drupalvm.com/en/latest/extras/pimpmylog/" target="_blank" class="btn btn-info btn-xs" role="button">Documentation</a>
               </td>
             </tr>
           {%- endif -%}
         {%- endif %}
         {% if 'solr' in installed_extras -%}
-          {% set servername %}{{ vagrant_hostname }}:{{ solr_port }}/solr/{% endset %}
+          {% macro servername() %}{{ vagrant_hostname }}:{{ solr_port }}/solr/{% endmacro %}
           <tr>
             <th>Solr</th>
-            <td><a href="http://{{ servername }}">{{ servername }}</a></td>
+            <td><a href="http://{{ servername() }}">{{ servername() }}</a></td>
             <td class="text-right">
-              <a href="http://{{ servername }}" class="btn btn-success btn-xs" role="button">Open</a>
+              <a href="http://{{ servername() }}" class="btn btn-success btn-xs" role="button">Open</a>
               <a href="http://docs.drupalvm.com/en/latest/extras/solr/" target="_blank" class="btn btn-info btn-xs" role="button">Documentation</a>
             </td>
           </tr>
         {%- endif %}
         {% if 'xhprof' in installed_extras -%}
-          {% set servername = getServernameFromDocroot(php_xhprof_html_dir) %}
-          {%- if servername -%}
+          {% macro servername() %}{{ getServernameFromDocroot(php_xhprof_html_dir) }}{% endmacro %}
+          {%- if servername() -%}
             <tr>
               <th>XHProf</th>
-              <td><a href="http://{{ servername }}">{{ servername }}</a></td>
+              <td><a href="http://{{ servername() }}">{{ servername() }}</a></td>
               <td class="text-right">
-                <a href="http://{{ servername }}" class="btn btn-success btn-xs" role="button">Open</a>
+                <a href="http://{{ servername() }}" class="btn btn-success btn-xs" role="button">Open</a>
                 <a href="http://docs.drupalvm.com/en/latest/extras/xhprof/" target="_blank" class="btn btn-info btn-xs" role="button">Documentation</a>
               </td>
             </tr>

--- a/provisioning/templates/drupalvm-local.aliases.drushrc.php.j2
+++ b/provisioning/templates/drupalvm-local.aliases.drushrc.php.j2
@@ -6,8 +6,6 @@
  * @see example.aliases.drushrc.php.
  */
 
-{% set devtool_docroots = [adminer_install_dir, pimpmylog_install_dir, php_xhprof_html_dir, dashboard_install_dir] %}
-
 {% macro alias(host, root) %}
 $aliases['{{ host }}'] = array(
   'uri' => '{{ host }}',
@@ -18,13 +16,13 @@ $aliases['{{ host }}'] = array(
 
 {%- if drupalvm_webserver == 'apache' -%}
   {%- for vhost in apache_vhosts -%}
-    {%- if vhost.documentroot not in devtool_docroots -%}
+    {%- if vhost.documentroot not in _devtool_docroots -%}
       {{ alias(vhost.servername, vhost.documentroot) }}
     {%- endif -%}
   {%- endfor -%}
 {%- elif drupalvm_webserver == 'nginx' -%}
   {%- for host in nginx_hosts -%}
-    {%- if host.root not in devtool_docroots -%}
+    {%- if host.root not in _devtool_docroots -%}
       {{ alias(host.server_name, host.root) }}
     {%- endif -%}
   {%- endfor -%}

--- a/provisioning/templates/drupalvm-local.aliases.drushrc.php.j2
+++ b/provisioning/templates/drupalvm-local.aliases.drushrc.php.j2
@@ -6,7 +6,7 @@
  * @see example.aliases.drushrc.php.
  */
 
-{% set devtool_docroots = [adminer_install_dir, pimpmylog_install_dir, php_xhprof_html_dir] %}
+{% set devtool_docroots = [adminer_install_dir, pimpmylog_install_dir, php_xhprof_html_dir, dashboard_install_dir] %}
 
 {% macro alias(host, root) %}
 $aliases['{{ host }}'] = array(

--- a/provisioning/templates/drupalvm.aliases.drushrc.php.j2
+++ b/provisioning/templates/drupalvm.aliases.drushrc.php.j2
@@ -6,8 +6,6 @@
  * @see example.aliases.drushrc.php.
  */
 
-{% set devtool_docroots = [adminer_install_dir, pimpmylog_install_dir, php_xhprof_html_dir, dashboard_install_dir] %}
-
 {% macro alias(host, root) %}
 $aliases['{{ host }}'] = array(
   'uri' => '{{ host }}',
@@ -21,13 +19,13 @@ $aliases['{{ host }}'] = array(
 
 {%- if drupalvm_webserver == 'apache' -%}
   {%- for vhost in apache_vhosts -%}
-    {%- if vhost.documentroot not in devtool_docroots -%}
+    {%- if vhost.documentroot not in _devtool_docroots -%}
       {{ alias(vhost.servername, vhost.documentroot) }}
     {%- endif -%}
   {%- endfor -%}
 {%- elif drupalvm_webserver == 'nginx' -%}
   {%- for host in nginx_hosts -%}
-    {%- if host.root not in devtool_docroots -%}
+    {%- if host.root not in _devtool_docroots -%}
       {{ alias(host.server_name, host.root) }}
     {%- endif -%}
   {%- endfor -%}

--- a/provisioning/templates/drupalvm.aliases.drushrc.php.j2
+++ b/provisioning/templates/drupalvm.aliases.drushrc.php.j2
@@ -6,7 +6,7 @@
  * @see example.aliases.drushrc.php.
  */
 
-{% set devtool_docroots = [adminer_install_dir, pimpmylog_install_dir, php_xhprof_html_dir] %}
+{% set devtool_docroots = [adminer_install_dir, pimpmylog_install_dir, php_xhprof_html_dir, dashboard_install_dir] %}
 
 {% macro alias(host, root) %}
 $aliases['{{ host }}'] = array(

--- a/provisioning/vars/main.yml
+++ b/provisioning/vars/main.yml
@@ -1,0 +1,6 @@
+---
+_devtool_docroots:
+  - "{{ adminer_install_dir }}"
+  - "{{ pimpmylog_install_dir }}"
+  - "{{ php_xhprof_html_dir }}"
+  - "{{ dashboard_install_dir|default('') }}"


### PR DESCRIPTION
First take at a dashboard mentioned in #320. I'm not sure how we would want to add this to the webserver actually? At the moment it doesn't work :smile: It works if you set `apache_remove_default_vhost: false` hehe

Also I've only tested minimally (only apache for example).

I used bootstrap so this wouldn't work if the user is offline. I feel that's still okay (the stylesheet is loaded at the end of the document not to pause the rendering), maybe add some minimal styling for such cases.

One minor hack is the `Adminer` link for each database. This links to `adminer.drupalvm.dev/?username=root&db=drupal`, which is actually an auto-login feature, but it fails due to not being configured. Instead it redirects the user back to login screen with an error message _AND_ also pre-fills the fields.

<img width="774" alt="screen shot 2016-01-30 at 12 32 29" src="https://cloud.githubusercontent.com/assets/302736/12697284/adab97d6-c74d-11e5-8f8b-adaa1f1e6adf.png">

