### PR TITLE
Helps with #379: Set drush_version explicitly to a string

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -172,7 +172,7 @@ ruby_install_gems: []
 # You can configure almost anything else on the server in the rest of this file.
 extra_security_enabled: false
 
-drush_version: master
+drush_version: "master"
 drush_keep_updated: true
 drush_composer_cli_options: "--prefer-dist --no-interaction"
 


### PR DESCRIPTION
This way the user would either leave it as a string, or maybe remember that it used to be a string when it fails. If you set `drush_version: "7"` it would still fail though as this is not the name of the branch (nor a tag).

> TASK [geerlingguy.drush : Clone Drush from GitHub.] ****************************
fatal: [drupalvmv]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to checkout 7"}

Now the error messages would at least help them figure it out. But maybe it's even worth adding a comment about it being a branch, and _not_ a version :)