### PR TITLE
PR #184, Issue #257: Add support for jinja variables in `config.yml` replacing hardcoded hosts and paths

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,6 +72,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         unless blacklist.include?(host['servername'])
           aliases.push(host['servername'])
         end
+        aliases.concat(host['serveralias'].split()) if host['serveralias']
       end
     else
       vconfig['nginx_hosts'].each do |host|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,16 @@ def which(cmd)
   return nil
 end
 
+def walk(obj, &fn)
+  if obj.is_a?(Array)
+    obj.map { |value| walk(value, &fn) }
+  elsif obj.is_a?(Hash)
+    obj.each_pair { |key, value| obj[key] = walk(value, &fn) }
+  else
+    obj = fn.call(obj)
+  end
+end
+
 # Use config.yml for basic VM configuration.
 require 'yaml'
 dir = File.dirname(File.expand_path(__FILE__))
@@ -21,6 +31,14 @@ if !File.exist?("#{dir}/config.yml")
   raise 'Configuration file not found! Please copy example.config.yml to config.yml and try again.'
 end
 vconfig = YAML::load_file("#{dir}/config.yml")
+
+# Replace jinja variables in config.
+vconfig = walk(vconfig) do |value|
+  while value.is_a?(String) && value.match(/{{ .* }}/)
+    value = value.gsub(/{{ (.*?) }}/) { |match| match = vconfig[$1] }
+  end
+  value
+end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
@@ -47,21 +65,22 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # If hostsupdater plugin is installed, add all server names as aliases.
   if Vagrant.has_plugin?("vagrant-hostsupdater")
-    config.hostsupdater.aliases = []
-    # Add all hosts that aren't defined as Ansible vars.
+    aliases = []
+    blacklist = [config.vm.hostname, vconfig['vagrant_ip']]
     if vconfig['drupalvm_webserver'] == "apache"
-      for host in vconfig['apache_vhosts']
-        unless host['servername'].include? "{{"
-          config.hostsupdater.aliases.push(host['servername'])
+      vconfig['apache_vhosts'].each do |host|
+        unless blacklist.include?(host['servername'])
+          aliases.push(host['servername'])
         end
       end
     else
-      for host in vconfig['nginx_hosts']
-        unless host['server_name'].include? "{{"
-          config.hostsupdater.aliases.push(host['server_name'])
+      vconfig['nginx_hosts'].each do |host|
+        unless blacklist.include?(host['server_name'])
+          aliases.push(host['server_name'])
         end
       end
     end
+    config.hostsupdater.aliases = aliases.uniq
   end
 
   # Synced folders.

--- a/docs/other/base-os.md
+++ b/docs/other/base-os.md
@@ -27,8 +27,6 @@ mysql_syslog_tag: mariadb
 mysql_pid_file: /var/run/mariadb/mariadb.pid
 ```
 
-**XHProf**: XHProf is installed in a different directory for RedHat/CentOS (as opposed to Debian/Ubuntu), you will need to update the `"xhprof.drupalvm.dev"` vhost to point to the `documentroot` `"/usr/share/pear/xhprof_html"`.
-
 ## RedHat Enterprise Linux / CentOS 6
 
 **Apache without FastCGI**: If you want to use Apache with CentOS 6 on Drupal VM, you will need to modify the syntax of your `apache_vhosts` and remove the `ProxyPassMatch` parameters from each one. Alternatively, you can use Nginx with the default configuration by setting `drupalvm_webserver: nginx` inside `config.yml`.
@@ -38,5 +36,3 @@ mysql_pid_file: /var/run/mariadb/mariadb.pid
 ```yaml
 php_opcache_enabled_in_ini: false
 ```
-
-**XHProf**: XHProf is installed in a different directory for RedHat/CentOS (as opposed to Debian/Ubuntu), you will need to update the `"xhprof.drupalvm.dev"` vhost to point to the `documentroot` `"/usr/share/pear/xhprof_html"`.

--- a/example.config.yml
+++ b/example.config.yml
@@ -83,19 +83,19 @@ apache_vhosts:
           ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ drupal_core_path }}"
 
   - servername: "adminer.{{ vagrant_machine_name }}"
-    documentroot: "/opt/adminer"
+    documentroot: "{{ adminer_install_dir }}"
     extra_parameters: |
-          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000/opt/adminer"
+          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ adminer_install_dir }}"
 
   - servername: "xhprof.{{ vagrant_machine_name }}"
-    documentroot: "/usr/share/php/xhprof_html"
+    documentroot: "{{ php_xhprof_html_dir }}"
     extra_parameters: |
-          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000/usr/share/php/xhprof_html"
+          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ php_xhprof_html_dir }}"
 
   - servername: "pimpmylog.{{ vagrant_machine_name }}"
-    documentroot: "/usr/share/php/pimpmylog"
+    documentroot: "{{ pimpmylog_install_dir }}"
     extra_parameters: |
-          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000/usr/share/php/pimpmylog"
+          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ pimpmylog_install_dir }}"
 
 apache_remove_default_vhost: true
 apache_mods_enabled:
@@ -114,15 +114,15 @@ nginx_hosts:
     is_php: true
 
   - server_name: "adminer.{{ vagrant_machine_name }}"
-    root: "/opt/adminer"
+    root: "{{ adminer_install_dir }}"
     is_php: true
 
   - server_name: "xhprof.{{ vagrant_machine_name }}"
-    root: "/usr/share/php/xhprof_html"
+    root: "{{ php_xhprof_html_dir }}"
     is_php: true
 
   - server_name: "pimpmylog.{{ vagrant_machine_name }}"
-    root: "/usr/share/php/pimpmylog"
+    root: "{{ pimpmylog_install_dir }}"
     is_php: true
 
 nginx_remove_default_vhost: true

--- a/example.config.yml
+++ b/example.config.yml
@@ -47,7 +47,7 @@ install_site: true
 # is 'true').
 drupal_major_version: 8
 drupal_core_path: "/var/www/drupalvm/drupal"
-drupal_domain: "drupalvm.dev"
+drupal_domain: "{{ vagrant_machine_name }}"
 drupal_site_name: "Drupal"
 drupal_install_profile: standard
 drupal_enable_modules: [ 'devel' ]
@@ -82,17 +82,17 @@ apache_vhosts:
     extra_parameters: |
           ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ drupal_core_path }}"
 
-  - servername: "adminer.drupalvm.dev"
+  - servername: "adminer.{{ vagrant_machine_name }}"
     documentroot: "/opt/adminer"
     extra_parameters: |
           ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000/opt/adminer"
 
-  - servername: "xhprof.drupalvm.dev"
+  - servername: "xhprof.{{ vagrant_machine_name }}"
     documentroot: "/usr/share/php/xhprof_html"
     extra_parameters: |
           ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000/usr/share/php/xhprof_html"
 
-  - servername: "pimpmylog.drupalvm.dev"
+  - servername: "pimpmylog.{{ vagrant_machine_name }}"
     documentroot: "/usr/share/php/pimpmylog"
     extra_parameters: |
           ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000/usr/share/php/pimpmylog"
@@ -113,15 +113,15 @@ nginx_hosts:
     root: "{{ drupal_core_path }}"
     is_php: true
 
-  - server_name: "adminer.drupalvm.dev"
+  - server_name: "adminer.{{ vagrant_machine_name }}"
     root: "/opt/adminer"
     is_php: true
 
-  - server_name: "xhprof.drupalvm.dev"
+  - server_name: "xhprof.{{ vagrant_machine_name }}"
     root: "/usr/share/php/xhprof_html"
     is_php: true
 
-  - server_name: "pimpmylog.drupalvm.dev"
+  - server_name: "pimpmylog.{{ vagrant_machine_name }}"
     root: "/usr/share/php/pimpmylog"
     is_php: true
 

--- a/provisioning/tasks/init-debian.yml
+++ b/provisioning/tasks/init-debian.yml
@@ -24,3 +24,8 @@
 - name: Add repository for PHP 7.0.
   apt_repository: repo='ppa:ondrej/php-7.0'
   when: php_version == "7.0"
+
+- name: Define php_xhprof_html_dir.
+  set_fact:
+    php_xhprof_html_dir: "/usr/share/php/xhprof_html"
+  when: php_xhprof_html_dir is not defined

--- a/provisioning/tasks/init-redhat.yml
+++ b/provisioning/tasks/init-redhat.yml
@@ -20,3 +20,8 @@
 - name: Enable remi repo for PHP 7.0.
   set_fact: php_enablerepo="remi,remi-php70"
   when: php_version == "7.0"
+
+- name: Define php_xhprof_html_dir.
+  set_fact:
+    php_xhprof_html_dir: "/usr/share/pear/xhprof_html"
+  when: php_xhprof_html_dir is not defined


### PR DESCRIPTION
Related PR/Issues:
- https://github.com/geerlingguy/drupal-vm/pull/184
- https://github.com/geerlingguy/drupal-vm/issues/257

This is really a second variation of #184 that's more generalised and supports jinja variables in any config value (as well as variables pointing to other variables: `servername: "{{ drupal_domain }}"` -> `drupal_domain: "{{ vagrant_machine_name }}"`).

[Beetbox](https://github.com/drupalmel/beetbox/blob/master/Vagrantfile#L38:L43) does something similar, but I added a recursive walker so we can support nested hashes/lists etc.