### PR TITLE
Use Docker-based Travis CI tests for multi-platform support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
       version: 6
       init: /sbin/init
       run_opts: "--privileged"
+      additional_vars: "centos-6-vars.yml"
     - distribution: centos
       version: 7
       init: /usr/lib/systemd/systemd
@@ -54,7 +55,7 @@ script:
   - 'sudo docker exec "$(cat ${container_id})" cp /var/www/drupalvm/$MAKEFILE /var/www/drupalvm/drupal.make.yml'
 
   # Append additional variables if set.
-  - '[[ $additional_vars ]] && sudo docker exec "$(cat ${container_id})" bash -c "cat /var/www/drupalvm/tests/${additional_vars} >> /var/www/drupalvm/config.yml"'
+  - '[[ $additional_vars ]] && sudo docker exec "$(cat ${container_id})" bash -c "cat /var/www/drupalvm/tests/${additional_vars} >> /var/www/drupalvm/config.yml" || true'
 
   # Ansible syntax check.
   - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /var/www/drupalvm/provisioning/playbook.yml --syntax-check'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,103 @@
----
-language: python
-python: "2.7"
+sudo: required
 
-install:
-  # Install Ansible.
-  - pip install ansible
+env:
+  global:
+    - CONFIG: example.config.yml
+      MAKEFILE: example.drupal.make.yml
+      HOSTNAME: drupalvm.dev
+      MACHINE_NAME: drupalvm
+  matrix:
+    - distribution: centos
+      version: 6
+      init: /sbin/init
+      run_opts: "--privileged"
+    - distribution: centos
+      version: 7
+      init: /usr/lib/systemd/systemd
+      run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+      additional_vars: "centos-7-vars.yml"
+  # - distribution: ubuntu
+  #   version: 14.04
+  #   init: /sbin/init
+  #   run_opts: "--privileged"
+  # - distribution: ubuntu
+  #   version: 12.04
+  #   init: /sbin/init
+  #   run_opts: "--privileged"
 
-  # Add ansible.cfg to set local roles path.
-  - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
+services:
+  - docker
+
+before_install:
+  # Pull container
+  - 'sudo docker pull ${distribution}:${version}'
+  # Customize container
+  - 'sudo docker build --rm=true --file=tests/Dockerfile.${distribution}-${version} --tag=${distribution}-${version}:ansible tests'
 
 script:
-  # Copy example files into place.
-  - cp example.config.yml config.yml
-  - cp example.drupal.make.yml drupal.make.yml
+  - container_id=$(mktemp)
 
-  # Make sure Ansible requirements install correctly.
-  - 'ansible-galaxy install -r provisioning/requirements.yml'
+  # Run container in detached state
+  - 'sudo docker run --detach --volume="${PWD}":/var/www/drupalvm/:rw ${run_opts} ${distribution}-${version}:ansible "${init}" > "${container_id}"'
 
-  # Run Ansible's syntax and playbook check on the main playbook.
-  - 'ansible-playbook -i "localhost," -c local provisioning/playbook.yml --syntax-check'
+  # Set hostname.
+  - 'sudo docker exec "$(cat ${container_id})" hostname ${HOSTNAME}'
 
-  # Check the config file and drupal make file YAML syntax.
+  # Setup directories.
+  - 'sudo docker exec "$(cat ${container_id})" mkdir -p /var/www/drupalvm/drupal'
+
+  # Install dependencies.
+  - 'sudo docker exec "$(cat ${container_id})" ansible-galaxy install -r /var/www/drupalvm/provisioning/requirements.yml'
+
+  # Copy configuration files into place.
+  - 'sudo docker exec "$(cat ${container_id})" cp /var/www/drupalvm/$CONFIG /var/www/drupalvm/config.yml'
+  - 'sudo docker exec "$(cat ${container_id})" cp /var/www/drupalvm/$MAKEFILE /var/www/drupalvm/drupal.make.yml'
+
+  # Append additional variables if set.
+  - '[[ $additional_vars ]] && sudo docker exec "$(cat ${container_id})" bash -c "cat /var/www/drupalvm/tests/${additional_vars} >> /var/www/drupalvm/config.yml"'
+
+  # Ansible syntax check.
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /var/www/drupalvm/provisioning/playbook.yml --syntax-check'
+
+  # Run the playbook with ansible-playbook.
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /var/www/drupalvm/provisioning/playbook.yml'
+
+  # Run the integration tests
   - >
-    python -c "import yaml; yaml.load( open('example.config.yml', 'r'), Loader=yaml.CLoader  )"
+    sudo docker exec "$(cat ${container_id})" curl -s --header Host:${HOSTNAME} localhost
+    | grep -q '<title>Welcome to Drupal'
+    && (echo 'Drupal install pass' && exit 0)
+    || (echo 'Drupal install fail' && exit 1)
+
   - >
-    python -c "import yaml; yaml.load( open('example.drupal.make.yml', 'r'), Loader=yaml.CLoader  )"
+    sudo docker exec "$(cat ${container_id})" curl -s --header Host:adminer.${HOSTNAME} localhost
+    | grep -q '<title>Login - Adminer'
+    && (echo 'Admin install pass' && exit 0)
+    || (echo 'Adminer install fail' && exit 1)
+
+  - >
+    sudo docker exec "$(cat ${container_id})" curl -s --header Host:pimpmylog.${HOSTNAME} localhost
+    | grep -q '<title>Pimp my Log'
+    && (echo 'Pimp my Log install pass' && exit 0)
+    || (echo 'Pimp my Log install fail' && exit 1)
+
+  - >
+    sudo docker exec "$(cat ${container_id})" curl -s --header Host:xhprof.${HOSTNAME} localhost
+    | grep -q '<title>XHProf'
+    && (echo 'XHProf install pass' && exit 0)
+    || (echo 'XHProf install fail' && exit 1)
+
+  - >
+    sudo docker exec "$(cat ${container_id})" curl -s localhost:8025
+    | grep -q '<title>MailHog'
+    && (echo 'MailHog install pass' && exit 0)
+    || (echo 'MailHog install fail' && exit 1)
+
+  - >
+    sudo docker exec "$(cat ${container_id})" drush @${MACHINE_NAME}.${HOSTNAME} status
+    | grep -q 'Drupal bootstrap.*Successful'
+    && (echo 'Drush install pass' && exit 0)
+    || (echo 'Drush install fail' && exit 1)
+
+  # Clean up
+  - 'sudo docker stop "$(cat ${container_id})"'

--- a/example.config.yml
+++ b/example.config.yml
@@ -37,7 +37,7 @@ drupalvm_webserver: apache
 # Set this to false if you are using a different site deployment strategy and
 # would like to configure 'vagrant_synced_folders' and 'apache_vhosts' manually.
 build_makefile: true
-drush_makefile_path: /vagrant/drupal.make.yml
+drush_makefile_path: ../../drupal.make.yml
 
 # Set this to false if you don't need to install drupal (using the drupal_*
 # settings below), but instead copy down a database (e.g. using drush sql-sync).

--- a/provisioning/tasks/build-makefile.yml
+++ b/provisioning/tasks/build-makefile.yml
@@ -1,4 +1,10 @@
 ---
+- name: Copy drush makefile into place.
+  copy:
+    src: "{{ drush_makefile_path }}"
+    dest: /tmp/drupal.make.yml
+  when: drupal_site.stat.exists == false
+
 - name: Ensure drupal_core_path directory exists.
   file:
     path: "{{ drupal_core_path }}"
@@ -9,7 +15,7 @@
 
 - name: Generate Drupal site with drush makefile.
   command: >
-    {{ drush_path }} make -y {{ drush_makefile_path }} --no-gitinfofile
+    {{ drush_path }} make -y /tmp/drupal.make.yml --no-gitinfofile
     chdir={{ drupal_core_path }}
   when: drupal_site.stat.exists == false
   become: no

--- a/provisioning/tasks/drush-aliases.yml
+++ b/provisioning/tasks/drush-aliases.yml
@@ -1,22 +1,4 @@
 ---
-- name: Ensure drush directory exists for vagrant user inside VM.
-  file: 'path="~/.drush" state=directory'
-  become: no
-
-- name: Configure drush aliases for vagrant user inside VM.
-  template:
-    src: ../templates/drupalvm-local.aliases.drushrc.php.j2
-    dest: "~/.drush/{{ vagrant_machine_name }}.aliases.drushrc.php"
-  become: no
-
-- name: Ensure drush directory exists for root user inside VM.
-  file: 'path="~/.drush" state=directory'
-
-- name: Configure drush aliases for root user inside VM.
-  template:
-    src: ../templates/drupalvm-local.aliases.drushrc.php.j2
-    dest: "~/.drush/{{ vagrant_machine_name }}.aliases.drushrc.php"
-
 - name: Check if local Drush configuration folder exists.
   stat:
     path: ~/.drush
@@ -41,3 +23,21 @@
   delegate_to: 127.0.0.1
   become: no
   when: configure_local_drush_aliases
+
+- name: Ensure drush directory exists for vagrant user inside VM.
+  file: 'path="~/.drush" state=directory'
+  become: no
+
+- name: Configure drush aliases for vagrant user inside VM.
+  template:
+    src: ../templates/drupalvm-local.aliases.drushrc.php.j2
+    dest: "~/.drush/{{ vagrant_machine_name }}.aliases.drushrc.php"
+  become: no
+
+- name: Ensure drush directory exists for root user inside VM.
+  file: 'path="~/.drush" state=directory'
+
+- name: Configure drush aliases for root user inside VM.
+  template:
+    src: ../templates/drupalvm-local.aliases.drushrc.php.j2
+    dest: "~/.drush/{{ vagrant_machine_name }}.aliases.drushrc.php"

--- a/tests/Dockerfile.centos-6
+++ b/tests/Dockerfile.centos-6
@@ -1,0 +1,15 @@
+FROM centos:6
+
+# Install Ansible
+RUN yum -y update; yum clean all;
+RUN yum -y install epel-release
+RUN yum -y install git ansible sudo which curl tar unzip xz logrotate
+RUN yum clean all
+
+# Disable requiretty
+RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
+
+# Install Ansible inventory file
+RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
+
+CMD ["/usr/sbin/init"]

--- a/tests/Dockerfile.centos-7
+++ b/tests/Dockerfile.centos-7
@@ -1,0 +1,27 @@
+FROM centos:7
+
+# Install systemd -- See https://hub.docker.com/_/centos/
+RUN yum -y swap -- remove fakesystemd -- install systemd systemd-libs
+RUN yum -y update; yum clean all; \
+(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*; \
+rm -f /etc/systemd/system/*.wants/*; \
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*; \
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+# Install Ansible
+RUN yum -y install epel-release
+RUN yum -y install git ansible sudo which curl tar unzip xz logrotate initscripts
+RUN yum clean all
+
+# Disable requiretty
+RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
+
+# Install Ansible inventory file
+RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
+
+VOLUME ["/sys/fs/cgroup"]
+CMD ["/usr/sbin/init"]

--- a/tests/Dockerfile.ubuntu-12.04
+++ b/tests/Dockerfile.ubuntu-12.04
@@ -1,0 +1,11 @@
+FROM ubuntu:12.04
+RUN apt-get update
+
+# Install Ansible
+RUN apt-get install -y software-properties-common python-software-properties git
+RUN apt-add-repository -y ppa:ansible/ansible
+RUN apt-get update
+RUN apt-get install -y ansible ufw curl
+
+# Install Ansible inventory file
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts

--- a/tests/Dockerfile.ubuntu-14.04
+++ b/tests/Dockerfile.ubuntu-14.04
@@ -1,0 +1,11 @@
+FROM ubuntu:14.04
+RUN apt-get update
+
+# Install Ansible
+RUN apt-get install -y software-properties-common git
+RUN apt-add-repository -y ppa:ansible/ansible
+RUN apt-get update
+RUN apt-get install -y ansible ufw curl
+
+# Install Ansible inventory file
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts

--- a/tests/centos-6-vars.yml
+++ b/tests/centos-6-vars.yml
@@ -1,0 +1,1 @@
+drupalvm_webserver: nginx

--- a/tests/centos-7-vars.yml
+++ b/tests/centos-7-vars.yml
@@ -1,0 +1,10 @@
+mysql_packages:
+  - mariadb
+  - mariadb-server
+  - mariadb-libs
+  - MySQL-python
+  - perl-DBD-MySQL
+mysql_daemon: mariadb
+mysql_log_error: /var/log/mariadb/mariadb.log
+mysql_syslog_tag: mariadb
+mysql_pid_file: /var/run/mariadb/mariadb.pid


### PR DESCRIPTION
I realised that we probably can't integrate these for a while due to stuff like https://github.com/geerlingguy/ansible-role-php-xhprof/issues/8, but I thought I'd send it over for some brainstorming.

1. I came up with at least a temporary solution for moving the `drush_makefile` to the VM before running it, instead of relying on it being a _vagrant_ environment. If https://github.com/geerlingguy/drupal-vm/pull/378 gets merged, we should pass the `host_project_root` var to ansible and use that instead. This issue was identified earlier in #84.

2. Also re-arranged the order of how drush files are generated so if run locally at least the local alias will be kept instead of overridden by an invalid remote alias.

3. Besides that I added some basic sanity checks to see that some of the stuff in the `example.config.yml` works out of the box. If we can get travis provisioned correctly, maybe we should create a `tests/` directory and move the tests there instead (so you could also run them locally). One rather nice test framework that could fit is [bats](https://github.com/sstephenson/bats). I've used it on a couple of projects before.

If you don't think we can run the entire playbook on `travis` (maybe just the test duration is too annoying already), I can cherry pick the other commits to separate PRs if you want. I guess even without the added tests, this would be a good step forward to solving #84.