### PR TITLE
Use php_fpm_listen

### DIFF
--- a/provisioning/templates/nginx-vhost.conf.j2
+++ b/provisioning/templates/nginx-vhost.conf.j2
@@ -34,7 +34,7 @@ server {
         fastcgi_intercept_errors on;
         fastcgi_read_timeout 120;
         include fastcgi_params;
-        fastcgi_pass 127.0.0.1:9000;
+        fastcgi_pass {{ php_fpm_listen }};
     }
 
     location @rewrite {


### PR DESCRIPTION
Use the nginx vhost template to use `php_fpm_listen` rather than hard-coding it into the template.

I've also opened a PR upstream to update this variable for Debian/Ubuntu servers. https://github.com/geerlingguy/ansible-role-php/pull/78