### PR TITLE
Issue #349, #162: Add SSL docs

### DIFF
--- a/docs/extras/ssl.md
+++ b/docs/extras/ssl.md
@@ -1,0 +1,11 @@
+If you are using Ubuntu as your base OS and you want to get started quickly with a local development environment you can use the snakeoil certificate that is already generated.
+
+```yaml
+apache_vhosts_ssl:
+  - servername: "{{ drupal_domain }}"
+    documentroot: "{{ drupal_core_path }}"
+    certificate_file: "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+    certificate_key_file: "/etc/ssl/private/ssl-cert-snakeoil.key"
+    extra_parameters: |
+          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ drupal_core_path }}"
+```

--- a/docs/extras/ssl.md
+++ b/docs/extras/ssl.md
@@ -1,3 +1,25 @@
+To enable SSL support for you virtual hosts you first need a certificate file. You can generate a self-signed certificate with a command like
+
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout example.key -out example.crt
+
+Place the files in your project directory and add the following to your `config.yml`.
+
+```yaml
+apache_vhosts_ssl:
+  - servername: "{{ drupal_domain }}"
+    documentroot: "{{ drupal_core_path }}"
+    certificate_file: "/vagrant/example.crt"
+    certificate_key_file: "/vagrant/example.key"
+    extra_parameters: |
+          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ drupal_core_path }}"
+```
+
+_If you're using an actual production certificate you should of course **NOT** track it in git but transfer it to the VM before running `vagrant provision`_
+
+For a list of all configuration options see the [`geerlingguy.apache` Ansible role's README](https://github.com/geerlingguy/ansible-role-apache#readme).
+
+### Using Ubuntu's snakeoil certificate
+
 If you are using Ubuntu as your base OS and you want to get started quickly with a local development environment you can use the snakeoil certificate that is already generated.
 
 ```yaml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ pages:
     - 'Use Varnish with Drupal VM': 'extras/varnish.md'
     - 'Use MariaDB instead of MySQL': 'extras/mariadb.md'
     - 'Use Node.js and NPM': 'extras/nodejs.md'
+    - 'Use SSL vhosts with Apache': 'extras/ssl.md'
     - 'View Logs with Pimp my Log': 'extras/pimpmylog.md'
     - 'Profile Code with XHProf': 'extras/xhprof.md'
     - 'Debug Code with XDebug': 'extras/xdebug.md'


### PR DESCRIPTION
Is there any other way to transfer the certificate?
```sh
vagrant up
^Ctrl-C
vagrant ssh -c 'sudo mv /vagrant/example.cert ...'
vagrant provision
```

Just worried about suggesting something potentially dangerous if people use it for other things than simply testing SSL.