### PR TITLE
Add support for vagrant-hostmanager plugin.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,25 +63,30 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Vagrant box.
   config.vm.box = vconfig['vagrant_box']
 
-  # If hostsupdater plugin is installed, add all server names as aliases.
-  if Vagrant.has_plugin?("vagrant-hostsupdater")
-    aliases = []
-    blacklist = [config.vm.hostname, vconfig['vagrant_ip']]
-    if vconfig['drupalvm_webserver'] == "apache"
-      vconfig['apache_vhosts'].each do |host|
-        unless blacklist.include?(host['servername'])
-          aliases.push(host['servername'])
-        end
-        aliases.concat(host['serveralias'].split()) if host['serveralias']
+  # If a hostsfile manager plugin is installed, add all server names as aliases.
+  aliases = []
+  blacklist = [config.vm.hostname, vconfig['vagrant_ip']]
+  if vconfig['drupalvm_webserver'] == "apache"
+    vconfig['apache_vhosts'].each do |host|
+      unless blacklist.include?(host['servername'])
+        aliases.push(host['servername'])
       end
-    else
-      vconfig['nginx_hosts'].each do |host|
-        unless blacklist.include?(host['server_name'])
-          aliases.push(host['server_name'])
-        end
+      aliases.concat(host['serveralias'].split()) if host['serveralias']
+    end
+  else
+    vconfig['nginx_hosts'].each do |host|
+      unless blacklist.include?(host['server_name'])
+        aliases.push(host['server_name'])
       end
     end
+  end
+
+  if Vagrant.has_plugin?("vagrant-hostsupdater")
     config.hostsupdater.aliases = aliases.uniq
+  elsif Vagrant.has_plugin?("vagrant-hostmanager")
+    config.hostmanager.enabled = true
+    config.hostmanager.manage_host = true
+    config.hostmanager.aliases = aliases.uniq
   end
 
   # Synced folders.


### PR DESCRIPTION
This enables users to choose between using vagrant-hostsupdater and vagrant-hostmanager. See #444 