### PR TITLE
Rebase of #292 Ruby coding style fixes via rubocop in Vagrantfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ before_install:
   - 'sudo docker pull ${distribution}:${version}'
   # Customize container
   - 'sudo docker build --rm=true --file=tests/Dockerfile.${distribution}-${version} --tag=${distribution}-${version}:ansible tests'
+  # Install lint tools.
+  - 'gem install rubocop'
 
 script:
   - container_id=$(mktemp)
@@ -54,6 +56,9 @@ script:
 
   # Append additional variables if set.
   - '[[ $additional_vars ]] && sudo docker exec "$(cat ${container_id})" bash -c "cat /var/www/drupalvm/tests/${additional_vars} >> /var/www/drupalvm/config.yml" || true'
+
+  # Vagrantfile syntax check
+  - 'rubocop --except LineLength,Eval,MutableConstant'
 
   # Ansible syntax check.
   - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /var/www/drupalvm/provisioning/playbook.yml --syntax-check'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,17 +1,17 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
-VAGRANTFILE_API_VERSION = "2"
+VAGRANTFILE_API_VERSION = '2'
 
 # Cross-platform way of finding an executable in the $PATH.
 def which(cmd)
   exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
   ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
-    exts.each { |ext|
+    exts.each do |ext|
       exe = File.join(path, "#{cmd}#{ext}")
       return exe if File.executable?(exe) && !File.directory?(exe)
-    }
+    end
   end
-  return nil
+  nil
 end
 
 def walk(obj, &fn)
@@ -20,37 +20,36 @@ def walk(obj, &fn)
   elsif obj.is_a?(Hash)
     obj.each_pair { |key, value| obj[key] = walk(value, &fn) }
   else
-    obj = fn.call(obj)
+    obj = yield(obj)
   end
 end
 
 # Use config.yml for basic VM configuration.
 require 'yaml'
 dir = File.dirname(File.expand_path(__FILE__))
-if !File.exist?("#{dir}/config.yml")
+unless File.exist?("#{dir}/config.yml")
   raise 'Configuration file not found! Please copy example.config.yml to config.yml and try again.'
 end
-vconfig = YAML::load_file("#{dir}/config.yml")
+vconfig = YAML.load_file("#{dir}/config.yml")
 
 # Replace jinja variables in config.
 vconfig = walk(vconfig) do |value|
   while value.is_a?(String) && value.match(/{{ .* }}/)
-    value = value.gsub(/{{ (.*?) }}/) { |match| match = vconfig[$1] }
+    value = value.gsub(/{{ (.*?) }}/) { vconfig[Regexp.last_match(1)] }
   end
   value
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-
   # Networking configuration.
   config.vm.hostname = vconfig['vagrant_hostname']
-  if vconfig['vagrant_ip'] == "0.0.0.0" && Vagrant.has_plugin?("vagrant-auto_network")
-    config.vm.network :private_network, :ip => vconfig['vagrant_ip'], :auto_network => true
+  if vconfig['vagrant_ip'] == '0.0.0.0' && Vagrant.has_plugin?('vagrant-auto_network')
+    config.vm.network :private_network, ip: vconfig['vagrant_ip'], auto_network: true
   else
     config.vm.network :private_network, ip: vconfig['vagrant_ip']
   end
 
-  if !vconfig['vagrant_public_ip'].empty? && vconfig['vagrant_public_ip'] == "0.0.0.0"
+  if !vconfig['vagrant_public_ip'].empty? && vconfig['vagrant_public_ip'] == '0.0.0.0'
     config.vm.network :public_network
   elsif !vconfig['vagrant_public_ip'].empty?
     config.vm.network :public_network, ip: vconfig['vagrant_public_ip']
@@ -66,12 +65,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # If a hostsfile manager plugin is installed, add all server names as aliases.
   aliases = []
   blacklist = [config.vm.hostname, vconfig['vagrant_ip']]
-  if vconfig['drupalvm_webserver'] == "apache"
+  if vconfig['drupalvm_webserver'] == 'apache'
     vconfig['apache_vhosts'].each do |host|
       unless blacklist.include?(host['servername'])
         aliases.push(host['servername'])
       end
-      aliases.concat(host['serveralias'].split()) if host['serveralias']
+      aliases.concat(host['serveralias'].split) if host['serveralias']
     end
   else
     vconfig['nginx_hosts'].each do |host|
@@ -81,43 +80,43 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-  if Vagrant.has_plugin?("vagrant-hostsupdater")
+  if Vagrant.has_plugin?('vagrant-hostsupdater')
     config.hostsupdater.aliases = aliases.uniq
-  elsif Vagrant.has_plugin?("vagrant-hostmanager")
+  elsif Vagrant.has_plugin?('vagrant-hostmanager')
     config.hostmanager.enabled = true
     config.hostmanager.manage_host = true
     config.hostmanager.aliases = aliases.uniq
   end
 
   # Synced folders.
-  for synced_folder in vconfig['vagrant_synced_folders'];
+  vconfig['vagrant_synced_folders'].each do |synced_folder|
     options = {
       type: synced_folder['type'],
-      rsync__auto: "true",
+      rsync__auto: 'true',
       rsync__exclude: synced_folder['excluded_paths'],
-      rsync__args: ["--verbose", "--archive", "--delete", "-z", "--chmod=ugo=rwX"],
+      rsync__args: ['--verbose', '--archive', '--delete', '-z', '--chmod=ugo=rwX'],
       id: synced_folder['id'],
       create: synced_folder.include?('create') ? synced_folder['create'] : false,
       mount_options: synced_folder.include?('mount_options') ? synced_folder['mount_options'] : []
     }
-    if synced_folder.include?('options_override');
+    if synced_folder.include?('options_override')
       options = options.merge(synced_folder['options_override'])
     end
     config.vm.synced_folder synced_folder['local_path'], synced_folder['destination'], options
   end
 
   # Allow override of the default synced folder type.
-  config.vm.synced_folder ".", "/vagrant", type: vconfig.include?('vagrant_synced_folder_default_type') ? vconfig['vagrant_synced_folder_default_type'] : 'nfs'
+  config.vm.synced_folder '.', '/vagrant', type: vconfig.include?('vagrant_synced_folder_default_type') ? vconfig['vagrant_synced_folder_default_type'] : 'nfs'
 
   # Provisioning. Use ansible if it's installed, JJG-Ansible-Windows if not.
   if which('ansible-playbook')
-    config.vm.provision "ansible" do |ansible|
+    config.vm.provision 'ansible' do |ansible|
       ansible.playbook = "#{dir}/provisioning/playbook.yml"
     end
   else
-    config.vm.provision "shell" do |sh|
+    config.vm.provision 'shell' do |sh|
       sh.path = "#{dir}/provisioning/JJG-Ansible-Windows/windows.sh"
-      sh.args = "/provisioning/playbook.yml"
+      sh.args = '/provisioning/playbook.yml'
     end
   end
   # ansible_local provisioner is broken in Vagrant < 1.8.2.
@@ -131,11 +130,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # VMware Fusion.
   config.vm.provider :vmware_fusion do |v, override|
     # HGFS kernel module currently doesn't load correctly for native shares.
-    override.vm.synced_folder ".", "/vagrant", type: 'nfs'
+    override.vm.synced_folder '.', '/vagrant', type: 'nfs'
 
     v.gui = false
-    v.vmx["memsize"] = vconfig['vagrant_memory']
-    v.vmx["numvcpus"] = vconfig['vagrant_cpus']
+    v.vmx['memsize'] = vconfig['vagrant_memory']
+    v.vmx['numvcpus'] = vconfig['vagrant_cpus']
   end
 
   # VirtualBox.
@@ -144,8 +143,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.name = vconfig['vagrant_hostname']
     v.memory = vconfig['vagrant_memory']
     v.cpus = vconfig['vagrant_cpus']
-    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-    v.customize ["modifyvm", :id, "--ioapic", "on"]
+    v.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+    v.customize ['modifyvm', :id, '--ioapic', 'on']
   end
 
   # Parallels.
@@ -157,11 +156,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   # Set the name of the VM. See: http://stackoverflow.com/a/17864388/100134
-  config.vm.define vconfig['vagrant_machine_name'] do |d|
-  end
+  config.vm.define vconfig['vagrant_machine_name']
 
   # Allow an untracked Vagrantfile to modify the configurations
-  if File.exist?('Vagrantfile.local')
-    eval File.read 'Vagrantfile.local'
-  end
+  eval File.read 'Vagrantfile.local' if File.exist?('Vagrantfile.local')
 end


### PR DESCRIPTION
A rebase of #292. Also added rubocop check to travis.

According to https://docs.travis-ci.com/user/ci-environment/#Runtimes we do not need to specify the language as ruby because it's always installed.