### PR TITLE
Adding a note about the drush aliases NOT being valid for Windows by …

### DIFF
--- a/provisioning/templates/dashboard.html.j2
+++ b/provisioning/templates/dashboard.html.j2
@@ -78,7 +78,7 @@
             <th>Hostname</th>
             <th>Document Root</th>
             {% if configure_local_drush_aliases -%}
-              <th>Drush alias</th>
+              <th>Drush alias*</th>
             {%- endif %}
         </thead>
         <tbody>
@@ -91,6 +91,7 @@
               {{ printSite(host.server_name, host.root) }}
             {%- endfor -%}
           {%- endif %}
+          <tr><td colspan=3><small>*Note: Drush aliases are NOT created automatically on Windows. This is due to Ansible running from within the VM.</small></td></tr>
         </tbody>
       </table>
     {%- endmacro -%}


### PR DESCRIPTION
Hey guys, 

Love the new dashboard! Nice work on the latest couple of releases. 

One thing I noticed is that the drush aliases that come up are nice if you're not on Windows. Might be a good idea to add a little note about that. There is probably a better way to handle this as well but though I'd give it a shot. 

![drush-aliases-note](https://cloud.githubusercontent.com/assets/1117989/13357172/1b64494c-dc77-11e5-8c5f-daebd08580eb.jpg)
