### PR TITLE
Fix various alias issues in dashboard, hostsupdater and drush aliases

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,28 +64,25 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # If a hostsfile manager plugin is installed, add all server names as aliases.
   aliases = []
-  blacklist = [config.vm.hostname, vconfig['vagrant_ip']]
   if vconfig['drupalvm_webserver'] == 'apache'
     vconfig['apache_vhosts'].each do |host|
-      unless blacklist.include?(host['servername'])
-        aliases.push(host['servername'])
-      end
+      aliases.push(host['servername'])
       aliases.concat(host['serveralias'].split) if host['serveralias']
     end
   else
     vconfig['nginx_hosts'].each do |host|
-      unless blacklist.include?(host['server_name'])
-        aliases.push(host['server_name'])
-      end
+      aliases.concat(host['server_name'].split)
+      aliases.concat(host['server_name_redirect'].split) if host['server_name_redirect']
     end
   end
+  aliases = aliases.uniq - [config.vm.hostname, vconfig['vagrant_ip']]
 
   if Vagrant.has_plugin?('vagrant-hostsupdater')
-    config.hostsupdater.aliases = aliases.uniq
+    config.hostsupdater.aliases = aliases
   elsif Vagrant.has_plugin?('vagrant-hostmanager')
     config.hostmanager.enabled = true
     config.hostmanager.manage_host = true
-    config.hostmanager.aliases = aliases.uniq
+    config.hostmanager.aliases = aliases
   end
 
   # Synced folders.

--- a/provisioning/templates/dashboard.html.j2
+++ b/provisioning/templates/dashboard.html.j2
@@ -57,7 +57,7 @@
             {%- endif -%}
             {% if host.serveralias is defined -%}
               {%- for alias in host.serveralias.split() -%}
-                <li>{{ alias }} {{ vagrant_ip }}</li>
+                <li>{{ vagrant_ip }} {{ alias }}</li>
               {%- endfor -%}
             {%- endif %}
           {%- endfor -%}

--- a/provisioning/templates/dashboard.html.j2
+++ b/provisioning/templates/dashboard.html.j2
@@ -48,24 +48,37 @@
       {% endif %}
     {%- endmacro %}
 
+    {%- macro printHostsEntry(ip, servername) -%}
+      {%- if servername != ip -%}
+        <li>{{ ip }} {{ servername }}</li>
+      {%- endif -%}
+    {%- endmacro %}
+
     {%- macro sectionHost() -%}
       <ul class="section-host">
         {% if drupalvm_webserver == 'apache' -%}
           {%- for host in apache_vhosts -%}
-            {%- if host.documentroot != dashboard_install_dir -%}
-              <li>{{ vagrant_ip }} {{ host.servername }}</li>
-            {%- endif -%}
+
+            {{ printHostsEntry(vagrant_ip, host.servername) }}
             {% if host.serveralias is defined -%}
               {%- for alias in host.serveralias.split() -%}
-                <li>{{ vagrant_ip }} {{ alias }}</li>
+                {{ printHostsEntry(vagrant_ip, alias) }}
               {%- endfor -%}
             {%- endif %}
+
           {%- endfor -%}
         {%- elif drupalvm_webserver == 'nginx' -%}
           {%- for host in nginx_hosts -%}
-            {%- if host.root != dashboard_install_dir -%}
-              <li>{{ vagrant_ip }} {{ host.server_name }}</li>
-            {%- endif -%}
+
+            {% for server_name in host.server_name.split(' ') -%}
+              {{ printHostsEntry(vagrant_ip, server_name) }}
+            {%- endfor %}
+            {% if host.server_name_redirect is defined -%}
+              {%- for server_name in host.server_name_redirect.split(' ') -%}
+                {{ printHostsEntry(vagrant_ip, server_name) }}
+              {%- endfor -%}
+            {%- endif %}
+
           {%- endfor -%}
         {%- endif %}
       </ul>

--- a/provisioning/templates/drupalvm-local.aliases.drushrc.php.j2
+++ b/provisioning/templates/drupalvm-local.aliases.drushrc.php.j2
@@ -7,23 +7,28 @@
  */
 
 {% macro alias(host, root) %}
+{%- if root not in _devtool_docroots %}
 $aliases['{{ host }}'] = array(
   'uri' => '{{ host }}',
   'root' => '{{ root }}',
 );
 
+{% endif -%}
 {% endmacro %}
 
 {%- if drupalvm_webserver == 'apache' -%}
   {%- for vhost in apache_vhosts -%}
-    {%- if vhost.documentroot not in _devtool_docroots -%}
-      {{ alias(vhost.servername, vhost.documentroot) }}
+    {{ alias(vhost.servername, vhost.documentroot) }}
+    {%- if vhost.serveralias is defined -%}
+      {%- for serveralias in vhost.serveralias.split() -%}
+        {{ alias(serveralias, vhost.documentroot) }}
+      {%- endfor -%}
     {%- endif -%}
   {%- endfor -%}
 {%- elif drupalvm_webserver == 'nginx' -%}
   {%- for host in nginx_hosts -%}
-    {%- if host.root not in _devtool_docroots -%}
-      {{ alias(host.server_name.split(' ')[0], host.root) }}
-    {%- endif -%}
+    {%- for server_name in host.server_name.split() -%}
+      {{ alias(server_name, host.root) }}
+    {%- endfor -%}
   {%- endfor -%}
 {%- endif -%}

--- a/provisioning/templates/drupalvm-local.aliases.drushrc.php.j2
+++ b/provisioning/templates/drupalvm-local.aliases.drushrc.php.j2
@@ -23,7 +23,7 @@ $aliases['{{ host }}'] = array(
 {%- elif drupalvm_webserver == 'nginx' -%}
   {%- for host in nginx_hosts -%}
     {%- if host.root not in _devtool_docroots -%}
-      {{ alias(host.server_name, host.root) }}
+      {{ alias(host.server_name.split(' ')[0], host.root) }}
     {%- endif -%}
   {%- endfor -%}
 {%- endif -%}

--- a/provisioning/templates/drupalvm.aliases.drushrc.php.j2
+++ b/provisioning/templates/drupalvm.aliases.drushrc.php.j2
@@ -7,6 +7,7 @@
  */
 
 {% macro alias(host, root) %}
+{%- if root not in _devtool_docroots %}
 $aliases['{{ host }}'] = array(
   'uri' => '{{ host }}',
   'root' => '{{ root }}',
@@ -15,18 +16,22 @@ $aliases['{{ host }}'] = array(
   'ssh-options' => '-o PasswordAuthentication=no -i ~/.vagrant.d/insecure_private_key',
 );
 
+{% endif -%}
 {% endmacro %}
 
 {%- if drupalvm_webserver == 'apache' -%}
   {%- for vhost in apache_vhosts -%}
-    {%- if vhost.documentroot not in _devtool_docroots -%}
-      {{ alias(vhost.servername, vhost.documentroot) }}
+    {{ alias(vhost.servername, vhost.documentroot) }}
+    {%- if vhost.serveralias is defined -%}
+      {%- for serveralias in vhost.serveralias.split() -%}
+        {{ alias(serveralias, vhost.documentroot) }}
+      {%- endfor -%}
     {%- endif -%}
   {%- endfor -%}
 {%- elif drupalvm_webserver == 'nginx' -%}
   {%- for host in nginx_hosts -%}
-    {%- if host.root not in _devtool_docroots -%}
-      {{ alias(host.server_name.split(' ')[0], host.root) }}
-    {%- endif -%}
+    {%- for server_name in host.server_name.split() -%}
+      {{ alias(server_name, host.root) }}
+    {%- endfor -%}
   {%- endfor -%}
 {%- endif -%}

--- a/provisioning/templates/drupalvm.aliases.drushrc.php.j2
+++ b/provisioning/templates/drupalvm.aliases.drushrc.php.j2
@@ -26,7 +26,7 @@ $aliases['{{ host }}'] = array(
 {%- elif drupalvm_webserver == 'nginx' -%}
   {%- for host in nginx_hosts -%}
     {%- if host.root not in _devtool_docroots -%}
-      {{ alias(host.server_name, host.root) }}
+      {{ alias(host.server_name.split(' ')[0], host.root) }}
     {%- endif -%}
   {%- endfor -%}
 {%- endif -%}

--- a/provisioning/templates/nginx-vhost.conf.j2
+++ b/provisioning/templates/nginx-vhost.conf.j2
@@ -2,7 +2,7 @@
 server {
     listen       80;
     server_name  {{ item.server_name_redirect }};
-    return       301 http://{{ item.server_name }}$request_uri;
+    return       301 http://{{ item.server_name.split(' ')[0] }}$request_uri;
 }
 {% endif %}
 


### PR DESCRIPTION
**Needs manual testing** I'm on an even slower connection today, so wont be able to test it until some other day.

- This fixes: #479
- Simplifies the alias logic in `Vagrantfile`
- Support nginx aliases as well as redirects for hostsupdater/hostsmanager
- Fixes dashboard hosts entry logic never to ignore hosts, only ignore hosts when the entry becomes `192.168.88.88 192.168.88.88` (dashboard).
- Fixes broken drush aliases when nginx aliases are used.

I do not create drush aliases for every host alias intentionally. Only the first one will be used.