### PR TITLE
Updated PHP7 PPA.

### DIFF
--- a/provisioning/tasks/init-debian.yml
+++ b/provisioning/tasks/init-debian.yml
@@ -22,7 +22,7 @@
   when: php_version == "5.6"
 
 - name: Add repository for PHP 7.0.
-  apt_repository: repo='ppa:ondrej/php-7.0'
+  apt_repository: repo='ppa:ondrej/php'
   when: php_version == "7.0"
 
 - name: Define php_xhprof_html_dir.


### PR DESCRIPTION
PPA - https://launchpad.net/~ondrej/+archive/ubuntu/php-7.0 has been replaced by https://launchpad.net/~ondrej/+archive/ubuntu/php which supports both PHP 5.6 & 7

Fixes #491