### PR TITLE
Fix drush core-rsync not expanding ~ to $HOME

### DIFF
--- a/provisioning/templates/drupalvm.aliases.drushrc.php.j2
+++ b/provisioning/templates/drupalvm.aliases.drushrc.php.j2
@@ -13,7 +13,7 @@ $aliases['{{ host }}'] = array(
   'root' => '{{ root }}',
   'remote-host' => '{{ host }}',
   'remote-user' => '{{ vagrant_user }}',
-  'ssh-options' => '-o PasswordAuthentication=no -i ~/.vagrant.d/insecure_private_key',
+  'ssh-options' => '-o PasswordAuthentication=no -i ' . drush_server_home() . '/.vagrant.d/insecure_private_key',
 );
 
 {% endif -%}


### PR DESCRIPTION
`~` expansion is a shell feature that doesnt work with rsync -e flag.