### PR TITLE
[WIP] Add support for local.config.yml

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,18 +24,16 @@ def walk(obj, &fn)
   end
 end
 
-# Use config.yml, prod.config.yml and local.config.yml for VM configuration.
+# Use config.yml and local.config.yml for VM configuration.
 require 'yaml'
 dir = File.dirname(File.expand_path(__FILE__))
 unless File.exist?("#{dir}/config.yml")
   raise 'Configuration file not found! Please copy example.config.yml to config.yml and try again.'
 end
 vconfig = YAML.load_file("#{dir}/config.yml")
-# Include environment config files if available.
-['prod.config.yml', 'local.config.yml'].each do |file|
-  if File.exist?("#{dir}/#{file}")
-    vconfig.merge!(YAML.load_file("#{dir}/#{file}"))
-  end
+# Include a local.config.yml file if available.
+if File.exist?("#{dir}/local.config.yml")
+  vconfig.merge!(YAML.load_file("#{dir}/local.config.yml"))
 end
 
 # Replace jinja variables in config.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,12 +26,13 @@ end
 
 # Use config.yml, prod.config.yml and local.config.yml for VM configuration.
 require 'yaml'
-vconfig = {}
 dir = File.dirname(File.expand_path(__FILE__))
 unless File.exist?("#{dir}/config.yml")
   raise 'Configuration file not found! Please copy example.config.yml to config.yml and try again.'
 end
-['config.yml', 'prod.config.yml', 'local.config.yml'].each do |file|
+vconfig = YAML.load_file("#{dir}/config.yml")
+# Include environment config files if available.
+['prod.config.yml', 'local.config.yml'].each do |file|
   if File.exist?("#{dir}/#{file}")
     vconfig.merge!(YAML.load_file("#{dir}/#{file}"))
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,13 +24,18 @@ def walk(obj, &fn)
   end
 end
 
-# Use config.yml for basic VM configuration.
+# Use config.yml, prod.config.yml and local.config.yml for VM configuration.
 require 'yaml'
+vconfig = {}
 dir = File.dirname(File.expand_path(__FILE__))
 unless File.exist?("#{dir}/config.yml")
   raise 'Configuration file not found! Please copy example.config.yml to config.yml and try again.'
 end
-vconfig = YAML.load_file("#{dir}/config.yml")
+['config.yml', 'prod.config.yml', 'local.config.yml'].each do |file|
+  if File.exist?("#{dir}/#{file}")
+    vconfig.merge!(YAML.load_file("#{dir}/#{file}"))
+  end
+end
 
 # Replace jinja variables in config.
 vconfig = walk(vconfig) do |value|

--- a/docs/other/overriding-configurations.md
+++ b/docs/other/overriding-configurations.md
@@ -1,3 +1,24 @@
+## Overriding variables in `config.yml` with a `local.config.yml`
+
+If available, Drupal VM will also load a `local.config.yml` after having loaded the main `config.yml`. Using this file you can override variables previously defined in `config.yml`. For teams who are sharing a VM configuration, this is a good place to configure anything that's specific to your own environment.
+
+```yaml
+# Increase the memory available to your Drupal site.
+vagrant_memory: 1536
+php_memory_limit: "512M"
+
+# Override the synced folders to use rsync instead of NFS.
+vagrant_synced_folders:
+  - local_path: ~/Sites/drupalvm
+    destination: /var/www/drupalvm
+    type: rsync
+    create: true
+```
+
+_Note: The merge of the variables in these two files is shallow, so if you want to override a single item in a list, you will need to re-define all items in that list._
+
+## Extending the `Vagrantfile` with `Vagrantfile.local`
+
 Out of the box Drupal VM supports having VirtualBox, Parallels as well as VMware as a provider. Besides these there are multitude of others available (for example `vagrant-aws`, `vagrant-digitalocean`).
 
 If you want to use an unsupported provider, or otherwise modify the vagrant configuration in a way that is not exposed by Drupal VM, you can create a `Vagrantfile.local` in the root directory of this project.
@@ -16,7 +37,7 @@ config.vm.provider :virtualbox do |v|
 end
 ```
 
-## Example: Using the `vagrant-aws` provider
+### Example: Using the `vagrant-aws` provider
 
 Add the following variables to your `config.yml`.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,7 @@ pages:
   - Other Information:
     - 'Using Different Base OSes': 'other/base-os.md'
     - 'Using Different Webservers': 'other/webservers.md'
-    - 'Using a local Vagrantfile': 'other/local-vagrantfile.md'
+    - 'Overriding configurations': 'other/overriding-configurations.md'
     - 'PHP 7 on Drupal VM': 'other/php-7.md'
     - 'BigPipe with Drupal VM': 'other/bigpipe.md'
     - 'Drupal VM Management Tools': 'other/management-tools.md'

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -7,6 +7,11 @@
     - ../config.yml
 
   pre_tasks:
+    - include_vars: "{{ item }}"
+      with_fileglob:
+        - ../../prod.config.yml
+        - ../../local.config.yml
+
     - include: tasks/init-debian.yml
       when: ansible_os_family == 'Debian'
     - include: tasks/init-redhat.yml

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -9,7 +9,6 @@
   pre_tasks:
     - include_vars: "{{ item }}"
       with_fileglob:
-        - ../../prod.config.yml
         - ../../local.config.yml
 
     - include: tasks/init-debian.yml


### PR DESCRIPTION
This is a proof of concept that doesn't require Ansible 2.

New config loading logic:

1. `config.yml`
2. Include any files referenced in `extra_configs` list.
3. If available, and running through Vagrant, include `local.config.yml`
4. If available, and running directly through ansible, include `prod.config.yml`

If someone uses a vagrant plugin for deploying, such as for aws, they can add `env: prod` variable to their `config.yml` to include the prod config instead of the local config. Maybe this isn't a necessary feature?

I'm also assuming this would make #378 more difficult.

Edit: I simplified the PR to only support `local.config.yml` and `prod.config.yml`, both of which are included if available. Include order goes: `config.yml`, `prod.config.yml`, `local.config.yml`.