### PR TITLE
Update php-7.md

### DIFF
--- a/docs/other/php-7.md
+++ b/docs/other/php-7.md
@@ -34,7 +34,7 @@ php_extension_conf_paths:
 php_fpm_pool_conf_path: "/etc/php/7.0/fpm/pool.d/www.conf"
 ```
 
-Also, comment out `xhprof`, `xdebug`, `redis` and `memcached` from the `installed_extras` list, as these extensions are not yet supported for PHP 7 (as of late 2015).
+Also, comment out `xhprof`, `redis` and `memcached` from the `installed_extras` list, as these extensions are not yet supported for PHP 7 (as of late 2015).
 
 You can also build from source using the same/included `geerlingguy.php` Ansible role, but that process is a bit more involved and for power users comfortable with the process.
 

--- a/docs/other/php-7.md
+++ b/docs/other/php-7.md
@@ -23,10 +23,20 @@ php_packages:
   - php7.0-mbstring
 php_mysql_package: php7.0-mysql
 php_fpm_daemon: php7.0-fpm
+php_conf_paths: 
+  - /etc/php/7.0/fpm
+  - /etc/php/7.0/apache2
+  - /etc/php/7.0/cli
+php_extension_conf_paths:
+  - /etc/php/7.0/fpm/conf.d
+  - /etc/php/7.0/apache2/conf.d
+  - /etc/php/7.0/cli/conf.d
 php_fpm_pool_conf_path: "/etc/php/7.0/fpm/pool.d/www.conf"
 ```
 
 Also, comment out `xhprof`, `xdebug`, `redis` and `memcached` from the `installed_extras` list, as these extensions are not yet supported for PHP 7 (as of late 2015).
+
+Xdebug 2.4.0 works with PHP 7.0. Sources available at https://xdebug.org/files/xdebug-2.4.0.tgz but you'll need to update `ansible-role-php-xdebug` to pick the source from there.
 
 You can also build from source using the same/included `geerlingguy.php` Ansible role, but that process is a bit more involved and for power users comfortable with the process.
 

--- a/docs/other/php-7.md
+++ b/docs/other/php-7.md
@@ -36,8 +36,6 @@ php_fpm_pool_conf_path: "/etc/php/7.0/fpm/pool.d/www.conf"
 
 Also, comment out `xhprof`, `xdebug`, `redis` and `memcached` from the `installed_extras` list, as these extensions are not yet supported for PHP 7 (as of late 2015).
 
-Xdebug 2.4.0 works with PHP 7.0. Sources available at https://xdebug.org/files/xdebug-2.4.0.tgz but you'll need to update `ansible-role-php-xdebug` to pick the source from there.
-
 You can also build from source using the same/included `geerlingguy.php` Ansible role, but that process is a bit more involved and for power users comfortable with the process.
 
 ## RedHat/CentOS 7


### PR DESCRIPTION
The main change is to document the `php_conf_paths` and `php_extension_conf_paths` you need to get `php.ini` settings etc into the right directories. Also added a note to say that Xdebug 2.4.0 works with PHP7.0 ... but this would depend upon another pull request I made for `ansible-role-php-xdebug`