### PR TITLE
Support an optional playbook override file (example use: adding custom roles)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ vagrant_ansible_inventory_default
 config.yml
 drupal.make.yml
 Vagrantfile.local
+provisioning/playbook.local.yml
 examples/prod/inventory
 examples/prod/bootstrap/vars.yml
 scripts/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ There are a couple places where you can customize the VM for your needs:
 
   - `config.yml`: Contains variables like the VM domain name and IP address, PHP and MySQL configuration, etc.
   - `drupal.make.yml`: Contains configuration for the Drupal core version, modules, and patches that will be downloaded on Drupal's initial installation (more about [Drush make files](https://www.drupal.org/node/1432374)).
+  - `provisioning/playbook.local.yml`: Contains an optional playbook override file. See example.playbook.local.yml.
 
 If you want to switch from Drupal 8 (default) to Drupal 7 or 6 on the initial install, do the following:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -106,20 +106,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder '.', '/vagrant', type: vconfig.include?('vagrant_synced_folder_default_type') ? vconfig['vagrant_synced_folder_default_type'] : 'nfs'
 
   # Provisioning. Use ansible if it's installed, JJG-Ansible-Windows if not.
+  playbook = File.exist?("#{dir}/provisioning/playbook.local.yml") ? 'playbook.local.yml' : 'playbook.yml'
   if which('ansible-playbook')
     config.vm.provision 'ansible' do |ansible|
-      ansible.playbook = "#{dir}/provisioning/playbook.yml"
+      ansible.playbook = "#{dir}/provisioning/{playbook}"
     end
   else
     config.vm.provision 'shell' do |sh|
       sh.path = "#{dir}/provisioning/JJG-Ansible-Windows/windows.sh"
-      sh.args = '/provisioning/playbook.yml'
+      sh.args = "/provisioning/{playbook}"
     end
   end
   # ansible_local provisioner is broken in Vagrant < 1.8.2.
   # else
   #   config.vm.provision "ansible_local" do |ansible|
-  #     ansible.playbook = "provisioning/playbook.yml"
+  #     ansible.playbook = "provisioning/{playbook}"
   #     ansible.galaxy_role_file = "provisioning/requirements.yml"
   #   end
   # end

--- a/example.playbook.local.yml
+++ b/example.playbook.local.yml
@@ -1,0 +1,13 @@
+---
+# You will most likely want to build on top of the default playbook.
+- include: provisioning/playbook.yml
+
+# Add additional roles.
+- hosts: all
+  become: yes
+
+  roles:
+    # Example: A role from ansible-galaxy not already in the drupal-vm playbook.
+    - geerlingguy.svn
+    # Example: A custom PECL yaml role added to provisioning/roles/my-php-yaml.
+    - my-php-yaml


### PR DESCRIPTION
Here's a PR for discussion. This mimicking what we did on another project inspired by your Ansible talk at DrupalCon Austin @geerlingguy 😄 

Looking through your [examples](https://github.com/geerlingguy/drupal-vm/tree/master/examples) it wasn't clear to me if there is a better way to add custom roles than this?