### PR TITLE
Fixes NewRelic errors from the Playbook as the repo at franklinkim.ne…

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -43,7 +43,7 @@
     - { role: geerlingguy.pimpmylog, when: '"pimpmylog" in installed_extras' }
     - { role: geerlingguy.daemonize, when: '"mailhog" in installed_extras' }
     - { role: geerlingguy.mailhog, when: '"mailhog" in installed_extras' }
-    - { role: franklinkim.newrelic, when: '"newrelic" in installed_extras' }
+    # - { role: franklinkim.newrelic, when: '"newrelic" in installed_extras' }
     - { role: geerlingguy.nodejs, when: '"nodejs" in installed_extras' }
     - { role: geerlingguy.redis, when: '"redis" in installed_extras' }
     - { role: geerlingguy.php-redis, when: '"redis" in installed_extras' }

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -1,6 +1,6 @@
 ---
 - src: arknoll.selenium
-- src: franklinkim.newrelic
+# - src: franklinkim.newrelic
 - src: geerlingguy.adminer
 - src: geerlingguy.apache
 - src: geerlingguy.apache-php-fpm


### PR DESCRIPTION
Fixes NewRelic errors from the Playbook as the repo at franklinkim.newrelic isn't currently shared to the public.

Causes the following error:

```
ERROR! the role 'franklinkim.newrelic' was not found in ~/Sites/drupal-vm/provisioning/roles:~/Sites/drupal-vm/provisioning:/usr/local/etc/ansible/roles

The error appears to have been in '~/Sites/drupal-vm/provisioning/playbook.yml': line 46, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    - { role: geerlingguy.mailhog, when: '"mailhog" in installed_extras' }
    - { role: franklinkim.newrelic, when: '"newrelic" in installed_extras' }
      ^ here

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```