### PR TITLE
Fixes #598: Add support for pre_provision_scripts.

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -226,8 +226,9 @@ composer_home_group: "{{ drupalvm_user }}"
 # composer_global_packages:
 #   - { name: phpunit/phpunit, release: '@stable' }
 
-# Run specified scripts after VM is provisioned. Path is relative to the
-# `provisioning/playbook.yml` file.
+# Run specified scripts before or after VM is provisioned. Path is relative to
+# the `provisioning/playbook.yml` file.
+pre_provision_scripts: []
 post_provision_scripts: []
   # - "../examples/scripts/configure-solr.sh"
 

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -12,6 +12,11 @@
     - include: tasks/init-redhat.yml
       when: ansible_os_family == 'RedHat'
 
+    - name: Run configured pre-provision shell scripts.
+      script: "{{ item }}"
+      with_items: "{{ pre_provision_scripts }}"
+      when: pre_provision_scripts is defined
+
     - name: Set the PHP webserver daemon correctly when nginx is in use.
       set_fact:
         php_webserver_daemon: nginx


### PR DESCRIPTION
First approach—allow scripts to be run prior to role installation... note that this means things like Git aren't guaranteed to be available, and pre-provision scripts would need to at a minimum install any required dependencies before running.

If a script needs other dependencies present, it may be best to use a post provision script instead...?