### PR TITLE
Fix misleading error message when attempting to install drupal without a codebase

### DIFF
--- a/provisioning/tasks/install-site.yml
+++ b/provisioning/tasks/install-site.yml
@@ -4,7 +4,7 @@
     {{ drush_path }} status bootstrap
     chdir={{ drupal_core_path }}
   register: drupal_site_installed
-  failed_when: false
+  failed_when: "drupal_site_installed.stdout is undefined"
   changed_when: false
   become: no
 


### PR DESCRIPTION
Related #500 #605.

Before:

> TASK [Install Drupal with drush.] **********************************************
fatal: [drupalvm_tester]: FAILED! => {"failed": true, "msg": "The conditional check ''Successful' not in drupal_site_installed.stdout' failed. The error was: error while evaluating conditional ('Successful' not in drupal_site_installed.stdout): Unable to look up a name or access an attribute in template string. Make sure your variable name does not contain invalid characters like '-'.\n\nThe error appears to have been in '/Users/cindy/Projects/Personal/drupalvm-varnish/provisioning/tasks/install-site.yml': line 13, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Install Drupal with drush.\n  ^ here\n"}

After:

> TASK [Check if site is already installed.] *************************************
fatal: [drupalvm_tester]: FAILED! => {"changed": false, "failed": true, "failed_when_result": true, "module_stderr": "", "module_stdout": "Traceback (most recent call last):\r\n  File \"/home/vagrant/.ansible/tmp/ansible-tmp-1462997275.49-211280299519137/command\", line 2409, in <module>\r\n    main()\r\n  File \"/home/vagrant/.ansible/tmp/ansible-tmp-1462997275.49-211280299519137/command\", line 187, in main\r\n    os.chdir(chdir)\r\nOSError: [Errno 2] No such file or directory: '/var/www/drupalvm/drupal'\r\n", "msg": "MODULE FAILURE", "parsed": false}