### PR TITLE
Issue #614: Install cron jobs as the SSH user instead of as root

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -60,8 +60,8 @@ drupal_mysql_database: drupal
 # Additional arguments or options to pass to `drush site-install`.
 drupal_site_install_extra_args: []
 
-# Cron jobs are added to the root user's crontab. Keys include name (required),
-# minute, hour, day, weekday, month, job (required), and state.
+# Cron jobs are added to the vagrant user's crontab. Keys include name
+# (required), minute, hour, day, weekday, month, job (required), and state.
 drupalvm_cron_jobs: []
   # - {
   #   name: "Drupal Cron",

--- a/provisioning/tasks/cron.yml
+++ b/provisioning/tasks/cron.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure configured cron jobs exist in root account's crontab.
+- name: Ensure configured cron jobs exist in user account's crontab.
   cron:
     name: "{{ item.name }}"
     minute: "{{ item.minute | default('*') }}"
@@ -11,3 +11,4 @@
     state: "{{ item.state | default('present') }}"
   with_items: "{{ drupalvm_cron_jobs }}"
   when: drupalvm_cron_jobs is defined
+  become: no


### PR DESCRIPTION
This is mostly a security measurement for users provisioning a production environment.