### PR TITLE
Add support for custom pre/post ansible tasks.

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -21,6 +21,11 @@
       with_items: "{{ pre_provision_scripts }}"
       when: pre_provision_scripts is defined
 
+    - include: "{{ item }}"
+      with_fileglob:
+        - "{{ custom_pre_tasks_directory }}"
+      when: custom_pre_tasks_directory is defined
+
     - name: Set the PHP webserver daemon correctly when nginx is in use.
       set_fact:
         php_webserver_daemon: nginx
@@ -95,3 +100,8 @@
       script: "{{ item }}"
       with_items: "{{ post_provision_scripts }}"
       when: post_provision_scripts is defined
+
+    - include: "{{ item }}"
+      with_fileglob:
+        - "{{ custom_post_tasks_directory }}"
+      when: custom_post_tasks_directory is defined


### PR DESCRIPTION
Allow for custom playbook tasks without modifying the playbook.

You can define `custom_pre_tasks_directory` and/or `custom_post_tasks_directory` in your config to a path which will contain custom tasks. 

These are run in alphabetical order.