### PR TITLE
Issue #635: Documentation for PHP 5.6 does not have php_fpm_pool_conf_path

### DIFF
--- a/docs/other/php-56.md
+++ b/docs/other/php-56.md
@@ -34,6 +34,7 @@ php_extension_conf_paths:
   - /etc/php5/cli/conf.d
 php_fpm_daemon: php5-fpm
 php_fpm_conf_path: "/etc/php5/fpm"
+php_fpm_pool_conf_path: "/etc/php5/fpm/pool.d/www.conf"
 php_mysql_package: php5-mysql
 php_memcached_package: php5-memcached
 


### PR DESCRIPTION
This pull request solves the issue #635 adding the php_fpm_pool_conf_path configuration for PHP 5.6 documentation.