### PR TITLE
Issue #641: Fix so that optional variables are in fact optional

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -18,7 +18,7 @@
 
     - name: Run configured pre-provision shell scripts.
       script: "{{ item }}"
-      with_items: "{{ pre_provision_scripts|default(omit) }}"
+      with_items: "{{ pre_provision_scripts|default([]) }}"
 
     - name: Run configured pre-provision ansible task files.
       include: "{{ item }}"
@@ -97,7 +97,7 @@
 
     - name: Run configured post-provision shell scripts.
       script: "{{ item }}"
-      with_items: "{{ post_provision_scripts|default(omit) }}"
+      with_items: "{{ post_provision_scripts|default([]) }}"
 
     - name: Run configured post-provision ansible task files.
       include: "{{ item }}"

--- a/provisioning/tasks/cron.yml
+++ b/provisioning/tasks/cron.yml
@@ -9,6 +9,5 @@
     month: "{{ item.month | default('*') }}"
     job: "{{ item.job }}"
     state: "{{ item.state | default('present') }}"
-  with_items: "{{ drupalvm_cron_jobs }}"
-  when: drupalvm_cron_jobs is defined
+  with_items: "{{ drupalvm_cron_jobs|default([]) }}"
   become: no


### PR DESCRIPTION
So turns omit `with_items` did not like `omit`. Unlike `with_fileglob` which had no issue. I guess it's because `with_fileglob` doesnt fail with 0 matches.

Falling back to an empty list works for `with_items` though.