### PR TITLE
Set roles install path to provisioning/roles. [ci skip]

### DIFF
--- a/docs/other/php-56.md
+++ b/docs/other/php-56.md
@@ -1,6 +1,6 @@
 Drupal VM defaults to PHP 7, but you can install and use 5.6 if you need to maximize compatibility with older Drupal 6 and 7 sites.
 
-_Note: If you have Ansible installed on your host machine, make sure you're running the latest version of all Ansible role dependencies by running `ansible-galaxy install -r provisioning/requirements.yml --force` inside the root Drupal VM project folder._
+_Note: If you have Ansible installed on your host machine, make sure you're running the latest version of all Ansible role dependencies by running `ansible-galaxy install -p provisioning/roles -r provisioning/requirements.yml --force` inside the root Drupal VM project folder._
 
 ## Ubuntu 16.04
 


### PR DESCRIPTION
The ansible.cfg file sets "roles_path = ./roles".

The vagrant provisioner installs the roles in provisioning/roles.

