### PR TITLE
Set roles install path to provisioning/roles.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-roles_path = ./roles
+roles_path = ./provisioning/roles


### PR DESCRIPTION
Vagrant provisioner installs the roles in provisioning/roles.