### PR TITLE
Set ssh_home as default pwd for SSH.

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -292,3 +292,4 @@ selenium_version: 2.46.0
 # Other configuration.
 dashboard_install_dir: /var/www/dashboard
 known_hosts_path: ~/.ssh/known_hosts
+#ssh_home: "{{ drupal_core_path }}"

--- a/provisioning/tasks/sshd.yml
+++ b/provisioning/tasks/sshd.yml
@@ -19,3 +19,13 @@
     mode: 0644
   become: no
   when: known_hosts_file.stat.exists
+
+- name: Set SSH home directory.
+  lineinfile:
+    dest: "/home/{{ drupalvm_user }}/.bashrc"
+    state: present
+    create: yes
+    regexp: "^SSH_HOME="
+    line: "SSH_HOME={{ ssh_home }} && [ -e $SSH_HOME ] && cd $SSH_HOME"
+  become: no
+  when: ssh_home is defined


### PR DESCRIPTION
cd to `drupal_core_path` when SSHing to the VM. #661 

*note: this will be ignored if not set and fail gracefully if the path doesn't exist.