### PR TITLE
Separate PPAs for PHP 5.5, 5.6 are now deprecated. 

### DIFF
--- a/provisioning/tasks/init-debian.yml
+++ b/provisioning/tasks/init-debian.yml
@@ -20,17 +20,9 @@
   apt_repository: repo='ppa:ondrej/apache2'
   when: ansible_distribution_release == "precise" and ansible_distribution == "Ubuntu"
 
-- name: Add repository for PHP 5.5.
-  apt_repository: repo='ppa:ondrej/php5'
-  when: php_version == "5.5" and ansible_distribution == "Ubuntu" and ansible_distribution_version == "12.04"
-
-- name: Add repository for PHP 5.6.
-  apt_repository: repo='ppa:ondrej/php5-5.6'
-  when: php_version == "5.6" and ansible_distribution == "Ubuntu" and ansible_distribution_version != "16.04"
-
-- name: Add repository for PHP 7.0.
+- name: Add repository for PHP.
   apt_repository: repo='ppa:ondrej/php'
-  when: php_version == "7.0" and ansible_distribution == "Ubuntu" and ansible_distribution_version != "16.04"
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_version != "16.04"
 
 - name: Define php_xhprof_html_dir.
   set_fact:


### PR DESCRIPTION
The PPA maintainer has now deprecated `php5` & `php5-5.6` -- https://launchpad.net/~ondrej

`***** The main PPA for PHP (5.5, 5.6, 7.0) with many PECL extensions *****`
https://launchpad.net/~ondrej/+archive/ubuntu/php