### PR TITLE
Fixes incompatibility of dashboard and vagrant_ip set to 0.0.0.0

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -97,8 +97,7 @@ apache_vhosts:
     extra_parameters: |
           ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ pimpmylog_install_dir }}"
 
-  - servername: "{{ vagrant_ip }}"
-    serveralias: "dashboard.{{ vagrant_hostname }}"
+  - servername: "dashboard.{{ vagrant_hostname }}"
     documentroot: "{{ dashboard_install_dir }}"
 
 apache_remove_default_vhost: true
@@ -129,7 +128,7 @@ nginx_hosts:
     root: "{{ pimpmylog_install_dir }}"
     is_php: true
 
-  - server_name: "{{ vagrant_ip }} dashboard.{{ vagrant_hostname }}"
+  - server_name: "dashboard.{{ vagrant_hostname }}"
     root: "{{ dashboard_install_dir }}"
 
 nginx_remove_default_vhost: true


### PR DESCRIPTION
When using vagrant-auto_network plugin.