### PR TITLE
Issue #709: Add strict vagrant version requirement for easier debugging

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 VAGRANTFILE_API_VERSION = '2'
+Vagrant.require_version '>= 1.8.1'
 
 # Absolute paths on the host machine.
 host_drupalvm_dir = File.dirname(File.expand_path(__FILE__))


### PR DESCRIPTION
I think we've had a few of these issues as well and this makes it super clear

> This Vagrant environment has specified that it requires the Vagrant
version to satisfy the following version requirements:

> \>= 1.8.1

> You are running Vagrant 1.x.x, which does not satisfy
these requirements. Please change your Vagrant version or update
the Vagrantfile to allow this Vagrant version. However, be warned
that if the Vagrantfile has specified another version, it probably has
good reason to do so, and changing that may cause the environment to
not function properly.