### PR TITLE
Add www.drupalvm.dev as a default webserver alias

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -92,6 +92,7 @@ configure_drush_aliases: true
 # View the geerlingguy.apache Ansible Role README for more options.
 apache_vhosts:
   - servername: "{{ drupal_domain }}"
+    serveralias: "www.{{ drupal_domain }}"
     documentroot: "{{ drupal_core_path }}"
     extra_parameters: |
           ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ drupal_core_path }}"
@@ -130,7 +131,7 @@ apache_mods_enabled:
 # here. Set the 'is_php' property for document roots that contain PHP apps like
 # Drupal.
 nginx_hosts:
-  - server_name: "{{ drupal_domain }}"
+  - server_name: "{{ drupal_domain }} www.{{ drupal_domain }}"
     root: "{{ drupal_core_path }}"
     is_php: true
 


### PR DESCRIPTION
Maybe not such a useful feature but I add this to almost every project so I don't need to worry if the site was configured to redirect to `www` or not. Thought I'd send over a PR in case interested.