### PR TITLE
Support including extra_parameters for nginx vhosts

### DIFF
--- a/provisioning/templates/nginx-vhost.conf.j2
+++ b/provisioning/templates/nginx-vhost.conf.j2
@@ -90,4 +90,8 @@ server {
         image/x-icon;
     gzip_buffers 16 8k;
     gzip_min_length 512;
+
+{% if item.extra_parameters is defined %}
+    {{ item.extra_parameters }}
+{% endif %}
 }


### PR DESCRIPTION
From Using https on nginx #754

The provisioning/templates/nginx-vhost.conf.j2 template did not support the extra_parameters as in the template for ansible-role-nginx