### PR TITLE
Add elasticsearch to installed extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It will install the following on an Ubuntu 16.04 (by default) linux VM:
     - Drupal Console
     - Varnish 4.x (configurable)
     - Apache Solr 4.10.x (configurable)
+    - Elasticsearch
     - Node.js 0.12 (configurable)
     - Selenium, for testing your sites via Behat
     - Ruby

--- a/default.config.yml
+++ b/default.config.yml
@@ -174,6 +174,7 @@ installed_extras:
   - adminer
   # - blackfire
   - drupalconsole
+  # - elasticsearch
   - mailhog
   # - memcached
   # - newrelic
@@ -209,6 +210,7 @@ firewall_allowed_tcp_ports:
   - "8080"
   - "8443"
   - "8983"
+  - "9200"
 firewall_log_dropped_packets: false
 
 # PHP Configuration. Currently-supported versions: 5.6, 7.0.

--- a/docs/extras/elasticsearch.md
+++ b/docs/extras/elasticsearch.md
@@ -1,0 +1,24 @@
+[Elasticsearch](https://www.elastic.co/products/elasticsearch) is a search engine based on Lucene. It provides a distributed, multitenant-capable full-text search engine with an HTTP web interface and schema-free JSON documents.
+
+ To enable Elasticsearch in Drupal VM just make sure `elasticsearch` is in the list of `installed_extras` in your `config.yml`, and when you build Drupal VM, the latest version of Elasticsearch will be installed.
+
+The URL to connect to the local elasticsearch server (assuming you're using the default `elasticsearch_http_port` of 9200) from Drupal is:
+
+    http://localhost:9200
+    
+To access Elasticsearch from the host computer requires changing the IP address to listen on a specific interface, or 0.0.0.0 to listen on all interfaces.
+
+    elasticsearch_network_host: 0.0.0.0
+
+The Elasticsearch server can then be accessed at the configured domain:
+
+    http://drupalvm.dev:9200
+
+## Elasticsearch configuration
+
+You can add configuration for Elasticsearch by setting the appropriate variables inside `config.yml` before you build Drupal VM.
+
+    elasticsearch_network_host: localhost
+    elasticsearch_http_port: 9200
+
+Consult the [geerlingguy.elasticsearch](https://github.com/geerlingguy/ansible-role-elasticsearch) role for additional variables available for configuration.

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -68,9 +68,10 @@
     - { role: geerlingguy.redis, when: '"redis" in installed_extras' }
     - { role: geerlingguy.php-redis, when: '"redis" in installed_extras' }
     - { role: geerlingguy.ruby, when: '"ruby" in installed_extras' }
-    - { role: geerlingguy.java, when: '"solr" in installed_extras or "selenium" in installed_extras' }
+    - { role: geerlingguy.java, when: '"solr" in installed_extras or "selenium" in installed_extras or "elasticsearch" in installed_extras'}
     - { role: arknoll.selenium, when: '"selenium" in installed_extras' }
     - { role: geerlingguy.solr, when: '"solr" in installed_extras' }
+    - { role: geerlingguy.elasticsearch, when: '"elasticsearch" in installed_extras' }
     - { role: geerlingguy.varnish, when: '"varnish" in installed_extras' }
 
     # Roles for security and stability on production.

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -20,7 +20,7 @@
 - src: geerlingguy.drush
   version: 1.1.2
 - src: geerlingguy.elasticsearch
-  version: 2.0.1
+  version: 2.1.0
 - src: geerlingguy.firewall
   version: 1.0.9
 - src: geerlingguy.git

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -19,6 +19,8 @@
   version: 1.0.7
 - src: geerlingguy.drush
   version: 1.1.2
+- src: geerlingguy.elasticsearch
+  version: 2.0.1
 - src: geerlingguy.firewall
   version: 1.0.9
 - src: geerlingguy.git


### PR DESCRIPTION
Adds elasticsearch to installed extras.

Note:

For use on the host outside vagrant will depend on an upstream change like in PR's 9 or 17 or equivalent.

