### PR TITLE
Add ability to override drush make command line options.

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -39,6 +39,7 @@ drupalvm_webserver: apache
 # would like to configure 'vagrant_synced_folders' and 'apache_vhosts' manually.
 build_makefile: false
 drush_makefile_path: "{{ config_dir }}/drupal.make.yml"
+drush_make_options: "--no-gitinfofile"
 
 # Set 'build_makefile' to 'false' and this to 'true' if you are using a
 # composer based site deployment strategy.

--- a/provisioning/tasks/build-makefile.yml
+++ b/provisioning/tasks/build-makefile.yml
@@ -16,7 +16,7 @@
 
 - name: Generate Drupal site with drush makefile.
   command: >
-    {{ drush_path }} make -y /tmp/drupal.make.yml --no-gitinfofile
+    {{ drush_path }} make -y /tmp/drupal.make.yml {{ drush_make_options }}
     chdir={{ drupal_core_path }}
   when: not drupal_site_exists
   become: no


### PR DESCRIPTION
I needed to be able to customize the drush make command line options for a project. So, I added the ability to completely override the options used during provisioning. I think others may find it useful as well.