### PR TITLE
Remove shell-module touch in mysql role, use file-module instead.

### DIFF
--- a/provisioning/roles/geerlingguy.mysql/tasks/configure.yml
+++ b/provisioning/roles/geerlingguy.mysql/tasks/configure.yml
@@ -30,7 +30,9 @@
   notify: restart mysql
 
 - name: Create slow query log file (if configured).
-  shell: "touch {{ mysql_slow_query_log_file }} creates={{ mysql_slow_query_log_file }}"
+  file:
+    path: "{{ mysql_slow_query_log_file }}"
+    state: touch
   when: mysql_slow_query_log_enabled
 
 - name: Create datadir if it does not exist
@@ -52,7 +54,9 @@
   when: mysql_slow_query_log_enabled
 
 - name: Create error log file (if configured).
-  shell: "touch {{ mysql_log_error }} creates={{ mysql_log_error }}"
+  file:
+    path: "{{ mysql_log_error }}"
+    state: touch
   when: mysql_log == "" and mysql_log_error != ""
 
 - name: Set ownership on error log file (if configured).


### PR DESCRIPTION
This patch solves the WARNINGs during provisioning.