### PR TITLE
vagrant halt [id] causes "warning: already initialized constant VAGRANTFILE_API_VERSION"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
-VAGRANTFILE_API_VERSION = '2'
+VAGRANTFILE_API_VERSION = '2' unless defined? VAGRANTFILE_API_VERSION
 Vagrant.require_version '>= 1.8.1'
 
 # Absolute paths on the host machine.


### PR DESCRIPTION
When using the id argument for vagrant halt to act on a vagrant installation in a different directory a warning is currently generated.  This is due to the VAGRANTFILE_API_VERSION already being define.  This PR checks if it has been defined.

Warnings - 
```
Vagrantfile:3: warning: already initialized constant VAGRANTFILE_API_VERSION
```
```
Vagrantfile:3: warning: previous definition of VAGRANTFILE_API_VERSION was here
```
