### PR TITLE
Update default Selenium version to latest. Fixes #843

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -290,7 +290,7 @@ solr_xms: "64M"
 solr_xmx: "128M"
 
 # Selenium configuration.
-selenium_version: 2.46.0
+selenium_version: 2.53.0
 
 # Other configuration.
 dashboard_install_dir: /var/www/dashboard


### PR DESCRIPTION
Hey @geerlingguy I just updated drupal-vm default var per https://github.com/arknoll/ansible-role-selenium/pull/8. It solves my problem, which seemed to be the same as #843 so I added the closing command in the commit message (but of course let me know if that's not cool – you could always squash on commit and change it if you want).

Just for extra info, I ran into this trying to install Behat on drupal-vm release 3.2.0, following [Docs » Extra Software and Setup » Test with Behat and Selenium » Getting Started - Installing Prerequisites](http://docs.drupalvm.com/en/latest/extras/behat/#getting-started-installing-prerequisites).