### PR TITLE
If a synced folder's `owner` or `group` is set in `config.yml`, use it.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -107,7 +107,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       rsync__args: ['--verbose', '--archive', '--delete', '-z', '--chmod=ugo=rwX'],
       id: synced_folder['id'],
       create: synced_folder.include?('create') ? synced_folder['create'] : false,
-      mount_options: synced_folder.include?('mount_options') ? synced_folder['mount_options'] : nil
+      mount_options: synced_folder.include?('mount_options') ? synced_folder['mount_options'] : nil,
+      owner: synced_folder.include?('owner') ? synced_folder['owner'] : 'vagrant',
+      group: synced_folder.include?('group') ? synced_folder['group'] : 'vagrant'
     }
     if synced_folder.include?('options_override')
       options = options.merge(synced_folder['options_override'])


### PR DESCRIPTION
In some cases, [synced folders exhibit permissions issues as described in Drupal VM's documentation](http://docs.drupalvm.com/en/latest/extras/syncing-folders/#permissions-related-errors). The [suggested fix](https://github.com/geerlingguy/drupal-vm/issues/66#issuecomment-90184995) is currently to edit the `Vagrantfile` in such a way as to add `owner` and `group` options to Vagrant's mount operation. This forces end users to maintain a patched Vagrantfile that differs from the one under version control.

This patch addresses the issue by allowing an untracked `config.yml` file to set these synced folder options, instead. If no options for `owner` and `group` are explicitly defined, a default value of `vagrant` is set so as to conform to the [Vagrant default user conventions](https://www.vagrantup.com/docs/boxes/base.html#default-user-settings). As a result, if a user experiences this issue, they can write a `config.yml` section for synced folders that looks like the following while leaving the Drupal VM core `Vagrantfile` untouched:

``` yaml
vagrant_synced_folders:
  - local_path: "."
    destination: "/var/www/drupalvm"
    type: ""
    create: true
    owner: "www-data"
    group: "www-data"
```

With such a stanza in one's `config.yml` file, the executed `Vagrantfile` will be the equivalent of a line such as:

``` ruby
config.vm.synced_folder ".", "/var/www/drupalvm", owner: "www-data", group: "www-data", create: true
```
