### PR TITLE
config tweak to make PML more useful

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -100,6 +100,7 @@ apache_vhosts:
     documentroot: "{{ drupal_core_path }}"
     extra_parameters: |
           ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ drupal_core_path }}"
+          CustomLog ${APACHE_LOG_DIR}/access.log combined
 
   - servername: "adminer.{{ vagrant_hostname }}"
     documentroot: "{{ adminer_install_dir }}"


### PR DESCRIPTION
Adding an extra param for the main Apache vhost to use access.log makes PimpMyLog more useful with default settings.

Might be useful until a more configurable option is available.
#197
