### PR TITLE
Change php-fpm port so that xdebug works out of the box

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -99,28 +99,28 @@ apache_vhosts:
     serveralias: "www.{{ drupal_domain }}"
     documentroot: "{{ drupal_core_path }}"
     extra_parameters: |
-          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ drupal_core_path }}"
+          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9009{{ drupal_core_path }}"
 
   - servername: "adminer.{{ vagrant_hostname }}"
     documentroot: "{{ adminer_install_dir }}"
     extra_parameters: |
-          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ adminer_install_dir }}"
+          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9009{{ adminer_install_dir }}"
 
   - servername: "xhprof.{{ vagrant_hostname }}"
     documentroot: "{{ php_xhprof_html_dir }}"
     extra_parameters: |
-          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ php_xhprof_html_dir }}"
+          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9009{{ php_xhprof_html_dir }}"
 
   - servername: "pimpmylog.{{ vagrant_hostname }}"
     documentroot: "{{ pimpmylog_install_dir }}"
     extra_parameters: |
-          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ pimpmylog_install_dir }}"
+          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9009{{ pimpmylog_install_dir }}"
 
   - servername: "{{ vagrant_ip }}"
     serveralias: "dashboard.{{ vagrant_hostname }}"
     documentroot: "{{ dashboard_install_dir }}"
     extra_parameters: |
-          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ dashboard_install_dir }}"
+          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9009{{ dashboard_install_dir }}"
           DirectoryIndex index.html
 
 apache_remove_default_vhost: true
@@ -232,7 +232,7 @@ php_max_input_vars: "4000"
 # to instead use Apache + mod_php with an Ubuntu base box, make sure you add
 # libapache2-mod-php7.0 to `extra_packages` elsewhere in this config file.
 php_enable_php_fpm: true
-php_fpm_listen: "127.0.0.1:9000"
+php_fpm_listen: "127.0.0.1:9009"
 
 composer_path: /usr/bin/composer
 composer_home_path: "/home/{{ drupalvm_user }}/.composer"


### PR DESCRIPTION
Currently, the default config set php-fpm to listen on port 9000 and xdebug to listen on the same port.
When you turn on xdebug, it doesn't work out of the box and the variable to change its port is not visible in default.config.yml (php_xdebug_remote_port)

One of the ports, either php-fpm or xdebug, should be changed to avoid conflict in the default configuration.

I chose to change php-fpm because the xdebug port is set in all IDE to 9000 and if changed, it requires an extra step for the developer and needs to be documented. Changing php-fpm seems to give a better DX.