### PR TITLE
Fixes #925, Followup #859: Remi repo is not enabled for mysql by default

### DIFF
--- a/provisioning/tasks/init-redhat.yml
+++ b/provisioning/tasks/init-redhat.yml
@@ -9,7 +9,7 @@
 
 - name: Enable remi repo for MySQL.
   set_fact: mysql_enablerepo="remi"
-  when: mysql_enablerepo is not defined
+  when: mysql_enablerepo is not defined or mysql_enablerepo == ""
 
 - name: Enable remi repo for PHP 5.5.
   set_fact: php_enablerepo="remi,remi-php55"


### PR DESCRIPTION
I kept the functionality for

> Makes sense, if you want to use a different repo.

With this change you cannot disable the repo though.