### PR TITLE
Disable rubocop block length check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
   - '[[ ! -z "${local_config}" ]] && docker exec "$(cat ${container_id})" bash -c "cp ${DRUPALVM_DIR}/${local_config} ${config_dir:-$DRUPALVM_DIR}/local.config.yml" || true'
 
   # Vagrantfile syntax check.
-  - 'rubocop ./Vagrantfile --except LineLength,Eval,MutableConstant'
+  - 'rubocop ./Vagrantfile --except LineLength,Eval,MutableConstant,BlockLength'
 
   # Ansible syntax check.
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook ${DRUPALVM_DIR}/provisioning/playbook.yml --syntax-check'


### PR DESCRIPTION
Rubocop 0.44.0 introduced `Metric/BlockLength` https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0440-2016-10-13.

Travis failure:
https://travis-ci.org/geerlingguy/drupal-vm/jobs/167887473#L328