### PR TITLE
Issue #950: Allow sync folder type for cachier location to be configured

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -175,6 +175,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.cache.enable :apt
     # Cache the composer directory.
     config.cache.enable :generic, cache_dir: '/home/vagrant/.composer/cache'
+    config.cache.synced_folder_opts = {
+      type: vconfig.include?('vagrant_cachier_folder_default_type') ? vconfig['vagrant_cachier_folder_default_type'] : 'nfs'
+    }
   end
 
   # Allow an untracked Vagrantfile to modify the configurations

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -176,7 +176,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Cache the composer directory.
     config.cache.enable :generic, cache_dir: '/home/vagrant/.composer/cache'
     config.cache.synced_folder_opts = {
-      type: vconfig.include?('vagrant_cachier_folder_default_type') ? vconfig['vagrant_cachier_folder_default_type'] : 'nfs'
+      type: vconfig.include?('vagrant_synced_folder_default_type') ? vconfig['vagrant_synced_folder_default_type'] : 'nfs'
     }
   end
 

--- a/default.config.yml
+++ b/default.config.yml
@@ -4,7 +4,6 @@
 vagrant_box: geerlingguy/ubuntu1604
 vagrant_user: vagrant
 vagrant_synced_folder_default_type: nfs
-vagrant_cachier_folder_default_type: nfs
 
 # If you need to run multiple instances of Drupal VM, set a unique hostname,
 # machine name, and IP address for each instance.

--- a/default.config.yml
+++ b/default.config.yml
@@ -4,6 +4,7 @@
 vagrant_box: geerlingguy/ubuntu1604
 vagrant_user: vagrant
 vagrant_synced_folder_default_type: nfs
+vagrant_cachier_folder_default_type: nfs
 
 # If you need to run multiple instances of Drupal VM, set a unique hostname,
 # machine name, and IP address for each instance.


### PR DESCRIPTION
This commit allows the sync folder sharing type for the location of vagrant cachier to be
configured. It also sets it to 'nfs' as default.
