### PR TITLE
Install drupal/coder by default

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -257,6 +257,7 @@ composer_home_owner: "{{ drupalvm_user }}"
 composer_home_group: "{{ drupalvm_user }}"
 composer_global_packages:
   - { name: hirak/prestissimo, release: '^0.3' }
+  - { name: drupal/coder }
 
 # Run specified scripts before or after VM is provisioned. Path is relative to
 # the `provisioning/playbook.yml` file.


### PR DESCRIPTION
Drupal Coder is almost always required when developing with Drupal. It also implicitly installs codersniffer (as a dependency). It would be helpful if it was installed by default itself.

It is a very simple change that can be overridden in `config.yml`. Composer does the actual installation.