### PR TITLE
Issue #912: Fix Vagrant 1.8.6 failing to mount synced folders with empty mount_options

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -108,7 +108,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       rsync__args: ['--verbose', '--archive', '--delete', '-z', '--chmod=ugo=rwX'],
       id: synced_folder['id'],
       create: synced_folder.include?('create') ? synced_folder['create'] : false,
-      mount_options: synced_folder.include?('mount_options') ? synced_folder['mount_options'] : nil
+      mount_options: synced_folder.include?('mount_options') ? synced_folder['mount_options'] : []
     }
     if synced_folder.include?('options_override')
       options = options.merge(synced_folder['options_override'])


### PR DESCRIPTION
Haven't had time to manually verify this fix yet.