### PR TITLE
Fixes #847, Followup #848: Add docs on using vagrant-proxyconf

### DIFF
--- a/docs/other/overriding-configurations.md
+++ b/docs/other/overriding-configurations.md
@@ -80,4 +80,29 @@ Add the `AWS_ACCESS_KEY_ID` and the `AWS_SECRET_ACCESS_KEY` environment variable
 
 Then run `vagrant up --provider=aws` to provision the instance.
 
-_For additional configuring options read the [Vagrant AWS Provider's README](https://github.com/mitchellh/vagrant-aws#readme)_
+_For additional configuration options read the [Vagrant AWS Provider's README](https://github.com/mitchellh/vagrant-aws#readme)._
+
+### Example: Using Drupal VM behind a corporate proxy with `vagrant-proxyconf`
+
+Add the following variables to your `config.yml`.
+
+```yaml
+proxy_http: 'http://192.168.0.2:3128/'
+proxy_https: 'http://192.168.0.2:3128/'
+proxy_ftp: 'http://192.168.0.2:3128/'
+proxy_none: 'localhost,127.0.0.1,{{ drupal_domain }}'
+```
+
+Create a `Vagrantfile.local` in the root directory of your project.
+
+```ruby
+if Vagrant.has_plugin?('vagrant-proxyconf')
+  config.proxy.http = vconfig['proxy_http']
+  config.proxy.https = vconfig['proxy_https']
+  config.git_proxy.http = vconfig['proxy_http']
+  config.proxy.no_proxy = vconfig['proxy_none']
+  config.proxy.ftp = vconfig['proxy_ftp']
+end
+```
+
+_For additional configuration options read [Vagrant Proxyconf's README](https://github.com/tmatilai/vagrant-proxyconf#readme)._


### PR DESCRIPTION
The plugin already supports environment variables (`VAGRANT_HTTP_PROXY` etc) so I excluded those from @morsok original PR.

I keep piling docs into that _Overriding configurations_ section as I'm hesitant to create new topics 😄 