### PR TITLE
Issue #455: Allow for environment specific config files

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,8 @@ guest_project_dir = '/vagrant'
 guest_drupalvm_dir = ENV['DRUPALVM_DIR'] ? "/vagrant/#{ENV['DRUPALVM_DIR']}" : guest_project_dir
 guest_config_dir = ENV['DRUPALVM_CONFIG_DIR'] ? "/vagrant/#{ENV['DRUPALVM_CONFIG_DIR']}" : guest_project_dir
 
+environment = ENV['DRUPALVM_ENV'] = ENV['DRUPALVM_ENV'] || 'vagrant'
+
 # Cross-platform way of finding an executable in the $PATH.
 def which(cmd)
   exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
@@ -38,7 +40,7 @@ require 'yaml'
 # Load default VM configurations.
 vconfig = YAML.load_file("#{host_drupalvm_dir}/default.config.yml")
 # Use optional config.yml and local.config.yml for configuration overrides.
-['config.yml', 'local.config.yml'].each do |config_file|
+['config.yml', 'local.config.yml', "#{environment}.config.yml"].each do |config_file|
   if File.exist?("#{host_config_dir}/#{config_file}")
     vconfig.merge!(YAML.load_file("#{host_config_dir}/#{config_file}"))
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ guest_project_dir = '/vagrant'
 guest_drupalvm_dir = ENV['DRUPALVM_DIR'] ? "/vagrant/#{ENV['DRUPALVM_DIR']}" : guest_project_dir
 guest_config_dir = ENV['DRUPALVM_CONFIG_DIR'] ? "/vagrant/#{ENV['DRUPALVM_CONFIG_DIR']}" : guest_project_dir
 
-environment = ENV['DRUPALVM_ENV'] = ENV['DRUPALVM_ENV'] || 'vagrant'
+drupalvm_env = ENV['DRUPALVM_ENV'] || 'vagrant'
 
 # Cross-platform way of finding an executable in the $PATH.
 def which(cmd)
@@ -40,7 +40,7 @@ require 'yaml'
 # Load default VM configurations.
 vconfig = YAML.load_file("#{host_drupalvm_dir}/default.config.yml")
 # Use optional config.yml and local.config.yml for configuration overrides.
-['config.yml', 'local.config.yml', "#{environment}.config.yml"].each do |config_file|
+['config.yml', 'local.config.yml', "#{drupalvm_env}.config.yml"].each do |config_file|
   if File.exist?("#{host_config_dir}/#{config_file}")
     vconfig.merge!(YAML.load_file("#{host_config_dir}/#{config_file}"))
   end
@@ -126,14 +126,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provision 'ansible' do |ansible|
       ansible.playbook = "#{host_drupalvm_dir}/provisioning/playbook.yml"
       ansible.extra_vars = {
-        config_dir: host_config_dir
+        config_dir: host_config_dir,
+        drupalvm_env: drupalvm_env
       }
     end
   else
     config.vm.provision 'ansible_local' do |ansible|
       ansible.playbook = "#{guest_drupalvm_dir}/provisioning/playbook.yml"
       ansible.extra_vars = {
-        config_dir: guest_config_dir
+        config_dir: guest_config_dir,
+        drupalvm_env: drupalvm_env
       }
     end
   end

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -22,7 +22,7 @@
       with_fileglob:
         - "{{ config_dir }}/config.yml"
         - "{{ config_dir }}/local.config.yml"
-        - "{{ config_dir }}/{{ lookup('env', 'DRUPALVM_ENV')|default(drupalvm_env, true)|default(omit) }}.config.yml"
+        - "{{ config_dir }}/{{ lookup('env', 'DRUPALVM_ENV')|default(drupalvm_env, true)|default(ansible_env.DRUPALVM_ENV)|default(omit) }}.config.yml"
 
     - include: tasks/init-debian.yml
       when: ansible_os_family == 'Debian'

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -22,6 +22,7 @@
       with_fileglob:
         - "{{ config_dir }}/config.yml"
         - "{{ config_dir }}/local.config.yml"
+        - "{{ config_dir }}/{{ lookup('env', 'DRUPALVM_ENV') }}.config.yml"
 
     - include: tasks/init-debian.yml
       when: ansible_os_family == 'Debian'

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -22,7 +22,7 @@
       with_fileglob:
         - "{{ config_dir }}/config.yml"
         - "{{ config_dir }}/local.config.yml"
-        - "{{ config_dir }}/{{ lookup('env', 'DRUPALVM_ENV') }}.config.yml"
+        - "{{ config_dir }}/{{ lookup('env', 'DRUPALVM_ENV')|default(drupalvm_env, true)|default(omit) }}.config.yml"
 
     - include: tasks/init-debian.yml
       when: ansible_os_family == 'Debian'


### PR DESCRIPTION
This would allow for

```sh
# loads vagrant.config.yml if available
vagrant provision

# loads prod.config.yml if available
DRUPALVM_ENV=prod vagrant provision --provider=aws

# loads prod.config.yml if available
DRUPALVM_ENV=prod ansible-playbook -i examples/prod/inventory provisioning/playbook.yml --sudo --ask-sudo-pass

# doesn't try to load any other config file.
ansible-playbook -i examples/prod/inventory provisioning/playbook.yml --sudo --ask-sudo-pass

# add DRUPALVM_ENV=prod eg. in /etc/environment on remote host.
# loads prod.config.yml if available
ansible-playbook -i examples/prod/inventory provisioning/playbook.yml --sudo --ask-sudo-pass
```

Precedence from low to high:
1. `default.config.yml`
2. `config.yml`
3. `local.config.yml`
4. `{{ DRUPALVM_ENV }}.config.yml`