### PR TITLE
Allow for extra YAML config files to be loaded

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,9 +48,7 @@ vconfig = load_config_file("#{host_drupalvm_dir}/default.config.yml", true)
 vconfig.merge!(load_config_file("#{host_config_dir}/config.yml"))
 # Load user defined configuration files.
 vconfig['extra_config_files'].each do |extra_config_file|
-  Dir.glob("#{host_config_dir}/#{extra_config_file}").each do |config_file|
-    vconfig.merge!(load_config_file(config_file))
-  end
+  vconfig.merge!(load_config_file("#{host_config_dir}/#{extra_config_file}"))
 end
 # Load environment specific configuration overrides.
 vconfig.merge!(load_config_file("#{host_config_dir}/#{drupalvm_env}.config.yml"))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,7 @@ end
 
 def load_config_file(config_file, force = false)
   config = YAML.load_file(config_file) if force || File.exist?(config_file)
-  config or Hash.new
+  config || {}
 end
 
 require 'yaml'

--- a/default.config.yml
+++ b/default.config.yml
@@ -264,6 +264,11 @@ pre_provision_scripts: []
 post_provision_scripts: []
   # - "../examples/scripts/configure-solr.sh"
 
+# Include additional YAML config files located in the same directory as your
+# `config.yml`.
+extra_config_files:
+  - local.config.yml
+
 # MySQL Configuration.
 mysql_root_password: root
 mysql_slow_query_log_enabled: true

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -19,10 +19,20 @@
       when: config_dir is not defined
 
     - include_vars: "{{ item }}"
-      with_fileglob:
-        - "{{ config_dir }}/config.yml"
-        - "{{ config_dir }}/local.config.yml"
-        - "{{ config_dir }}/{{ lookup('env', 'DRUPALVM_ENV')|default(drupalvm_env, true)|default(ansible_env.DRUPALVM_ENV)|default(omit) }}.config.yml"
+      with_fileglob: "{{ config_dir }}/config.yml"
+
+    - name: Define _extra_config_files.
+      set_fact:
+        _extra_config_files: "{{ _extra_config_files|default([]) + [ config_dir + '/' + item] }}"
+      with_items: "{{ extra_config_files }}"
+
+    - name: Include extra_config_files.
+      include_vars: "{{ item }}"
+      with_fileglob: "{{ _extra_config_files }}"
+
+    - name: Include an environment specific config file.
+      include_vars: "{{ item }}"
+      with_fileglob: "{{ config_dir }}/{{ lookup('env', 'DRUPALVM_ENV')|default(drupalvm_env, true)|default(ansible_env.DRUPALVM_ENV)|default(omit) }}.config.yml"
 
     - include: tasks/init-debian.yml
       when: ansible_os_family == 'Debian'

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -18,21 +18,13 @@
         config_dir: "{{ playbook_dir }}/.."
       when: config_dir is not defined
 
-    - include_vars: "{{ item }}"
-      with_fileglob: "{{ config_dir }}/config.yml"
-
-    - name: Define _extra_config_files.
-      set_fact:
-        _extra_config_files: "{{ _extra_config_files|default([]) + [ config_dir + '/' + item] }}"
-      with_items: "{{ extra_config_files }}"
-
-    - name: Include extra_config_files.
-      include_vars: "{{ item }}"
-      with_fileglob: "{{ _extra_config_files }}"
-
-    - name: Include an environment specific config file.
-      include_vars: "{{ item }}"
-      with_fileglob: "{{ config_dir }}/{{ lookup('env', 'DRUPALVM_ENV')|default(drupalvm_env, true)|default(ansible_env.DRUPALVM_ENV)|default(omit) }}.config.yml"
+    - name: Include extra config files.
+      include_vars:
+        file: "{{ config_dir }}/{{ item }}"
+      with_flattened:
+        - config.yml
+        - "{{ extra_config_files }}"
+        - "{{ lookup('env', 'DRUPALVM_ENV')|default(drupalvm_env, true)|default(ansible_env.DRUPALVM_ENV)|default(omit) }}.config.yml"
 
     - include: tasks/init-debian.yml
       when: ansible_os_family == 'Debian'

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -20,7 +20,9 @@
 
     - name: Include extra config files.
       include_vars:
-        file: "{{ config_dir }}/{{ item }}"
+        dir: "{{ config_dir }}"
+        files_matching: "{{ item }}"
+        depth: 1
       with_flattened:
         - config.yml
         - "{{ extra_config_files }}"


### PR DESCRIPTION
The ansible tasks aren't as clean as I would like, but I couldn't come up with anything else.

This would support things like:

```
extra_config_files:
  - local.config.yml
  - configs/*.yml
  - configs/php/php56.yml
  - ../vendor/company/drupalvm-configs/varnish.yml
```

Thoughts?