### PR TITLE
Add vagrant-cachier composer caching for root user

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -179,6 +179,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.cache.enable :apt
     # Cache the composer directory.
     config.cache.enable :generic, cache_dir: '/home/vagrant/.composer/cache'
+    config.cache.enable :generic, cache_dir: '/root/.composer/cache'
     config.cache.synced_folder_opts = {
       type: vconfig.include?('vagrant_synced_folder_default_type') ? vconfig['vagrant_synced_folder_default_type'] : 'nfs'
     }


### PR DESCRIPTION
### Problem / Motivation

Some component of the composer-based provisioning is running as `root` and using `/root/.composer/...` on the guest machine.

While `Vagrantfile` enables `vagrant-cachier` caching for the `vagrant` user (and the respective composer cache in `/home/vagrant/.composer/cache`), the `root` user doesn't have the same.

I suspect the Drush installation is doing this, but it probably doesn't matter.  In the bigger picture, I think it's likely that some tasks will run `composer install` as `root` in the course of a project based on DrupalVM.

### Proposed solution

Add `/root/.composer/cache` as a `vagrant-cachier` cache.

This PR does that.