### PR TITLE
Fix prod/bootstrap/init not taking into account admin_copy_ssh_pubkey

### DIFF
--- a/examples/prod/bootstrap/init.yml
+++ b/examples/prod/bootstrap/init.yml
@@ -19,8 +19,9 @@
     - name: Add local SSH public key to admin account authorized_keys.
       authorized_key:
         user: "{{ admin_user }}"
-        key: "{{ lookup('file', '{{ admin_pubkey }}') }}"
+        key: "{{ lookup('file', admin_pubkey) }}"
         manage_dir: yes
+      when: admin_copy_ssh_pubkey
 
     - name: Disable requiretty.
       lineinfile:


### PR DESCRIPTION
The variable is listed in `example.vars.yml` but never actually used in the playbook.