### PR TITLE
Fix hostsupdater trying to add wildcard aliases

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -92,6 +92,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
   aliases = aliases.uniq - [config.vm.hostname, vconfig['vagrant_ip']]
+  # Remove wildcard subdomains.
+  aliases.delete_if { |vhost| vhost.include?('*') }
 
   if Vagrant.has_plugin?('vagrant-hostsupdater')
     config.hostsupdater.aliases = aliases


### PR DESCRIPTION
I was about to set up some wildcard vhosts when hostsupdater threw this:

```
==> drupalvm_project: [vagrant-hostsupdater] Checking for host entries
==> drupalvm_project: [vagrant-hostsupdater]   found entry for: 192.168.99.88 drupalvm-project.dev
/Users/cindy/.vagrant.d/gems/gems/vagrant-hostsupdater-1.0.2/lib/vagrant-hostsupdater/HostsUpdater.rb:80: warning: nested repeat operator '+' and '*' was replaced with '*' in regular expression
/Users/cindy/.vagrant.d/gems/gems/vagrant-hostsupdater-1.0.2/lib/vagrant-hostsupdater/HostsUpdater.rb:39: warning: nested repeat operator '+' and '*' was replaced with '*' in regular expression
/Users/cindy/.vagrant.d/gems/gems/vagrant-hostsupdater-1.0.2/lib/vagrant-hostsupdater/HostsUpdater.rb:39: warning: nested repeat operator '+' and '*' was replaced with '*' in regular expression
==> drupalvm_project: [vagrant-hostsupdater]   found entry for: 192.168.99.88 *.drupalvm-project.dev
==> drupalvm_project: Setting hostname...
==> drupalvm_project: Configuring and enabling network interfaces...
==> drupalvm_project: Exporting NFS shared folders...
==> drupalvm_project: Preparing to edit /etc/exports. Administrator privileges will be required...
```

After the PR:

```
==> drupalvm_project: [vagrant-hostsupdater] Checking for host entries
==> drupalvm_project: [vagrant-hostsupdater]   found entry for: 192.168.99.88 drupalvm-project.dev
==> drupalvm_project: Setting hostname...
==> drupalvm_project: Configuring and enabling network interfaces...
==> drupalvm_project: Exporting NFS shared folders...
==> drupalvm_project: Preparing to edit /etc/exports. Administrator privileges will be required...
```

Obviously there's no point in having those aliases in `/etc/hosts` either.