### PR TITLE
Allow user defined post-provision-tasks to use tags while drupal vm does not

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -20,12 +20,14 @@
       set_fact:
         config_dir: "{{ playbook_dir }}/.."
       when: config_dir is not defined
+      tags: ['always']
 
     - include_vars: "{{ item }}"
       with_fileglob:
         - "{{ config_dir }}/config.yml"
         - "{{ config_dir }}/local.config.yml"
         - "{{ config_dir }}/{{ lookup('env', 'DRUPALVM_ENV')|default(drupalvm_env, true)|default(ansible_env.DRUPALVM_ENV)|default(omit) }}.config.yml"
+      tags: ['always']
 
     - include: tasks/init-debian.yml
       when: ansible_os_family == 'Debian'


### PR DESCRIPTION
At the moment Drupal VM does not use ansible tags out of the box, but I wanted to use it for my own custom post-provision tasks. By default all the pre/post-provision tasks are excluded as the include statements are without tags.

This PR fixes the issue by delegating the decision of tags to the post-provision scripts. Rather than setting the tag to `user-provision` or something similar, I think they should be set it to `always` so that users can take full advantage of tags. http://docs.ansible.com/ansible/playbooks_tags.html#special-tags

```sh
DRUPALVM_ANSIBLE_ARGS='--tags=foobar' vagrant provision
```

Currently I'm only tagging the config includes and the post/pre-provision tasks. But maybe we should also tag _Include OS-specific variables._ and such?