### PR TITLE
Allow post-provision tasks to use the item variable

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -39,7 +39,9 @@
       with_items: "{{ pre_provision_scripts|default([]) }}"
 
     - name: Run configured pre-provision ansible task files.
-      include: "{{ item }}"
+      include: "{{ outer_item }}"
+      loop_control:
+        loop_var: outer_item
       with_fileglob:
         - "{{ pre_provision_tasks_dir|default(omit) }}"
 
@@ -156,6 +158,8 @@
       with_items: "{{ post_provision_scripts|default([]) }}"
 
     - name: Run configured post-provision ansible task files.
-      include: "{{ item }}"
+      include: "{{ outer_item }}"
+      loop_control:
+        loop_var: outer_item
       with_fileglob:
         - "{{ post_provision_tasks_dir|default(omit) }}"


### PR DESCRIPTION
Currently, if you use a loop inside a post/pre-provision taskfile ansible will complain if you use the `item` variable.

 > [WARNING]: The loop variable 'item' is already in use. You should set the
`loop_var` value in the `loop_control` option for the task to something else to
avoid variable collisions and unexpected behavior.

This makes DX a bit nicer by allowing the users to use that variable.