### PR TITLE
Install XHProf by default, reverts a6683f5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,14 @@ script:
 
   - >
     if [ $TEST_INSTALLED_EXTRAS = true ]; then
+      docker exec ${container_id} curl -s --header Host:xhprof.${HOSTNAME} localhost \
+      | grep -q '<title>XHProf' \
+      && (echo 'XHProf install pass' && exit 0) \
+      || (echo 'XHProf install fail' && exit 1)
+    fi
+
+  - >
+    if [ $TEST_INSTALLED_EXTRAS = true ]; then
       docker exec ${container_id} curl -s localhost:8025 \
       | grep -q '<title>MailHog' \
       && (echo 'MailHog install pass' && exit 0) \

--- a/default.config.yml
+++ b/default.config.yml
@@ -207,7 +207,7 @@ installed_extras:
   # - upload-progress
   - varnish
   # - xdebug
-  # - xhprof
+  - xhprof
 
 # Add any extra apt or yum packages you would like installed.
 extra_packages:


### PR DESCRIPTION
Just realized we add a XHProf vhost while we don't actually have xhprof enabled by default. https://github.com/geerlingguy/drupal-vm/commit/157b0edc1e247ffa30b375846069364c30cb1e02 removed XHProf from the default `installed_extras`, I assume it was because we didn't switch the package automatically before. With https://github.com/geerlingguy/drupal-vm/pull/1043 we set the correct package automatically so this should be safe to re-enable again.

That being said, we might also consider removing the vhost as the future of XHProf on PHP 7.1 looks pretty dark https://github.com/geerlingguy/drupal-vm/issues/1031. I think this PR is the correct fix at the moment, but maybe it's not worth changing the default `installed_extras` as we're probably switching to 7.1 as the default soon anyways.

Edit: Currently `service apache2 restart` outputs:

> AH00112: Warning: DocumentRoot [/usr/share/php/xhprof_html] does not exist