### PR TITLE
Configure hostname for environments other than VMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,6 @@ script:
   - 'docker run --detach --volume="${PWD}":${DRUPALVM_DIR}/:rw ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${tmpfile}"'
   - 'container_id=$(cat ${tmpfile})'
 
-  # Set hostname.
-  - 'docker exec ${container_id} hostname ${HOSTNAME}'
-
   # Setup directories.
   - 'docker exec ${container_id} mkdir -p ${DRUPALVM_DIR}/drupal'
 

--- a/examples/prod/prod.config.yml
+++ b/examples/prod/prod.config.yml
@@ -1,6 +1,7 @@
 ---
 # Normally, this would be set to the hostname of your DigitalOcean Droplet.
 drupal_domain: "drupalvm.dev"
+vagrant_hostname: "{{ drupal_domain }}"
 
 # Add only the `apache_vhosts` or `nginx_hosts` you need. If installing a
 # single Drupal site, the variable should look like this (Apache):

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -27,6 +27,8 @@
         - "{{ config_dir }}/local.config.yml"
         - "{{ config_dir }}/{{ lookup('env', 'DRUPALVM_ENV')|default(drupalvm_env, true)|default(ansible_env.DRUPALVM_ENV)|default(omit) }}.config.yml"
 
+    - include: tasks/hostname.yml
+
     - include: tasks/init-debian.yml
       when: ansible_os_family == 'Debian'
       static: no

--- a/provisioning/tasks/hostname.yml
+++ b/provisioning/tasks/hostname.yml
@@ -1,0 +1,26 @@
+- name: Define fully qualified domain name.
+  set_fact:
+    hostname_fqdn: "{{ vagrant_hostname }}"
+  when: hostname_fqdn is undefined
+
+- name: Define short hostname.
+  set_fact:
+    hostname_short: "{{ hostname_fqdn|regex_replace('^([^.]+).*$', '\\1') }}"
+  when: hostname_short is undefined
+
+- name: Add hostname to /etc/hosts.
+  lineinfile:
+    dest: /etc/hosts
+    regexp: '.*\t{{ hostname_short }}$'
+    line: "127.0.0.1\t{{ hostname_fqdn }}\t{{ hostname_short }}"
+    state: present
+
+- name: Configure hostname.
+  copy:
+    content: "{{ (ansible_os_family == 'Debian') | ternary(hostname_short, hostname_fqdn) }}\n"
+    dest: /etc/hostname
+  register: set_hostname
+
+- name: Set the hostname for current session.
+  shell: hostname --file /etc/hostname
+  when: set_hostname.changed

--- a/provisioning/tasks/init-debian.yml
+++ b/provisioning/tasks/init-debian.yml
@@ -12,6 +12,11 @@
     - sudo
     - unzip
 
+- name: Configure /etc/mailname.
+  copy:
+    content: "{{ hostname_fqdn }}\n"
+    dest: /etc/mailname
+
 - name: Disable the ufw firewall (since we use a simple iptables firewall).
   service: name=ufw state=stopped
   when: ansible_distribution == "Ubuntu" and {{ drupalvm_disable_ufw_firewall | default(true) }}


### PR DESCRIPTION
None of these tasks should issue `changed` state when provisioning for the first time–They should do the exact same thing as Vagrant does. I still haven't made sure of that.

- Debian uses the short hostname in `/etc/hostname` while RedHat uses the FQDN.
- `/etc/mailname` is a debian thing