### PR TITLE
Move ansible version requirements to Vagrantfile for better UX

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -133,17 +133,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Provisioning. Use ansible if it's installed, ansible_local if not or if forced.
   if ansible_bin && !vconfig['force_ansible_local']
-    if ansible_version >= ansible_version_min
-      config.vm.provision 'ansible' do |ansible|
-        ansible.playbook = "#{host_drupalvm_dir}/provisioning/playbook.yml"
-        ansible.extra_vars = {
-          config_dir: host_config_dir,
-          drupalvm_env: drupalvm_env
-        }
-        ansible.raw_arguments = ENV['DRUPALVM_ANSIBLE_ARGS']
-      end
-    else
+    if ansible_version < ansible_version_min
       raise "You must update Ansible to at least #{ansible_version_min} to use this version of Drupal VM."
+    end
+    config.vm.provision 'ansible' do |ansible|
+      ansible.playbook = "#{host_drupalvm_dir}/provisioning/playbook.yml"
+      ansible.extra_vars = {
+        config_dir: host_config_dir,
+        drupalvm_env: drupalvm_env
+      }
+      ansible.raw_arguments = ENV['DRUPALVM_ANSIBLE_ARGS']
     end
   else
     config.vm.provision 'ansible_local' do |ansible|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,10 @@ def which(cmd)
   nil
 end
 
+def get_ansible_version(exe)
+  /^[^\s]+ (.+)$/.match(`#{exe} --version`) { |match| return match[1] }
+end
+
 def walk(obj, &fn)
   if obj.is_a?(Array)
     obj.map { |value| walk(value, &fn) }
@@ -55,6 +59,10 @@ vconfig = walk(vconfig) do |value|
 end
 
 Vagrant.require_version ">= #{vconfig['drupalvm_vagrant_version_min']}"
+
+ansible_bin = which('ansible-playbook')
+ansible_version = Gem::Version.new(get_ansible_version(ansible_bin)) if ansible_bin
+ansible_version_min = Gem::Version.new(vconfig['drupalvm_ansible_version_min'])
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Networking configuration.
@@ -124,14 +132,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder host_project_dir, '/vagrant', type: vconfig.include?('vagrant_synced_folder_default_type') ? vconfig['vagrant_synced_folder_default_type'] : 'nfs'
 
   # Provisioning. Use ansible if it's installed, ansible_local if not or if forced.
-  if which('ansible-playbook') && !vconfig['force_ansible_local']
-    config.vm.provision 'ansible' do |ansible|
-      ansible.playbook = "#{host_drupalvm_dir}/provisioning/playbook.yml"
-      ansible.extra_vars = {
-        config_dir: host_config_dir,
-        drupalvm_env: drupalvm_env
-      }
-      ansible.raw_arguments = ENV['DRUPALVM_ANSIBLE_ARGS']
+  if ansible_bin && !vconfig['force_ansible_local']
+    if ansible_version >= ansible_version_min
+      config.vm.provision 'ansible' do |ansible|
+        ansible.playbook = "#{host_drupalvm_dir}/provisioning/playbook.yml"
+        ansible.extra_vars = {
+          config_dir: host_config_dir,
+          drupalvm_env: drupalvm_env
+        }
+        ansible.raw_arguments = ENV['DRUPALVM_ANSIBLE_ARGS']
+      end
+    else
+      raise "You must update Ansible to at least #{ansible_version_min} to use this version of Drupal VM."
     end
   else
     config.vm.provision 'ansible_local' do |ansible|

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -7,12 +7,6 @@
     - ../default.config.yml
 
   pre_tasks:
-    - name: Verify Ansible meets Drupal VM's version requirements.
-      assert:
-        that: "ansible_version.full | version_compare(drupalvm_ansible_version_min, '>=')"
-        msg: >
-          "You must update Ansible to at least {{ drupalvm_ansible_version_min }} to use this version of Drupal VM."
-
     - name: Include OS-specific variables.
       include_vars: "{{ ansible_os_family }}.yml"
 


### PR DESCRIPTION
Feature discussed in https://github.com/geerlingguy/drupal-vm/pull/1070#discussion_r93670548.

Example if requirement would be `2.3`:
```
drupal-vm cindy@cindy ansible-min-version*: vagrant status
/Users/cindy/Projects/Personal/drupal-vm/Vagrantfile:146:in `block in <top (required)>': You must update Ansible to at least 2.3 to use this version of Drupal VM. (RuntimeError)
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/config/v2/loader.rb:37:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/config/v2/loader.rb:37:in `load'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/config/loader.rb:113:in `block (2 levels) in load'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/config/loader.rb:107:in `each'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/config/loader.rb:107:in `block in load'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/config/loader.rb:104:in `each'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/config/loader.rb:104:in `load'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/vagrantfile.rb:28:in `initialize'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/environment.rb:746:in `new'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/environment.rb:746:in `vagrantfile'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/environment.rb:492:in `host'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/environment.rb:214:in `block in action_runner'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/runner.rb:33:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/action/runner.rb:33:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/environment.rb:479:in `hook'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/lib/vagrant/environment.rb:728:in `unload'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/bin/vagrant:177:in `ensure in <main>'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.8.6/bin/vagrant:177:in `<main>'
```