### PR TITLE
Use SetHandler fixing mod_rewrite and DirectoryIndex issues

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -106,29 +106,38 @@ apache_vhosts:
     serveralias: "www.{{ drupal_domain }}"
     documentroot: "{{ drupal_core_path }}"
     extra_parameters: |
-          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ drupal_core_path }}"
+          <FilesMatch \.php$>
+            SetHandler "proxy:unix:{{ php_fpm_listen }}|fcgi://{{ drupal_domain }}/"
+          </FilesMatch>
 
   - servername: "adminer.{{ vagrant_hostname }}"
     documentroot: "{{ adminer_install_dir }}"
     extra_parameters: |
-          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ adminer_install_dir }}"
+          <FilesMatch \.php$>
+            SetHandler "proxy:unix:{{ php_fpm_listen }}|fcgi://adminer.{{ vagrant_hostname }}/"
+          </FilesMatch>
 
   - servername: "xhprof.{{ vagrant_hostname }}"
     documentroot: "{{ php_xhprof_html_dir }}"
     extra_parameters: |
-          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ php_xhprof_html_dir }}"
+          <FilesMatch \.php$>
+            SetHandler "proxy:unix:{{ php_fpm_listen }}|fcgi://xhprof.{{ vagrant_hostname }}/"
+          </FilesMatch>
 
   - servername: "pimpmylog.{{ vagrant_hostname }}"
     documentroot: "{{ pimpmylog_install_dir }}"
     extra_parameters: |
-          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ pimpmylog_install_dir }}"
+          <FilesMatch \.php$>
+            SetHandler "proxy:unix:{{ php_fpm_listen }}|fcgi://pimpmylog.{{ vagrant_hostname }}/"
+          </FilesMatch>
 
   - servername: "{{ vagrant_ip }}"
     serveralias: "dashboard.{{ vagrant_hostname }}"
     documentroot: "{{ dashboard_install_dir }}"
     extra_parameters: |
-          ProxyPassMatch ^/(.*\.php(/.*)?)$ "fcgi://127.0.0.1:9000{{ dashboard_install_dir }}"
-          DirectoryIndex index.html
+          <FilesMatch \.php$>
+            SetHandler "proxy:unix:{{ php_fpm_listen }}|fcgi://dashboard.{{ vagrant_hostname }}/"
+          </FilesMatch>
 
 apache_remove_default_vhost: true
 apache_mods_enabled:
@@ -252,7 +261,7 @@ php_max_input_vars: "4000"
 # to instead use Apache + mod_php with an Ubuntu base box, make sure you add
 # libapache2-mod-php7.0 to `extra_packages` elsewhere in this config file.
 php_enable_php_fpm: true
-php_fpm_listen: "127.0.0.1:9000"
+php_fpm_listen: /var/run/php-fpm.sock
 
 composer_path: /usr/bin/composer
 composer_home_path: "/home/{{ drupalvm_user }}/.composer"

--- a/default.config.yml
+++ b/default.config.yml
@@ -107,28 +107,28 @@ apache_vhosts:
     documentroot: "{{ drupal_core_path }}"
     extra_parameters: |
           <FilesMatch \.php$>
-            SetHandler "proxy:unix:{{ php_fpm_listen }}|fcgi://{{ drupal_domain }}/"
+            SetHandler "proxy:fcgi://{{ php_fpm_listen }}"
           </FilesMatch>
 
   - servername: "adminer.{{ vagrant_hostname }}"
     documentroot: "{{ adminer_install_dir }}"
     extra_parameters: |
           <FilesMatch \.php$>
-            SetHandler "proxy:unix:{{ php_fpm_listen }}|fcgi://adminer.{{ vagrant_hostname }}/"
+            SetHandler "proxy:fcgi://{{ php_fpm_listen }}"
           </FilesMatch>
 
   - servername: "xhprof.{{ vagrant_hostname }}"
     documentroot: "{{ php_xhprof_html_dir }}"
     extra_parameters: |
           <FilesMatch \.php$>
-            SetHandler "proxy:unix:{{ php_fpm_listen }}|fcgi://xhprof.{{ vagrant_hostname }}/"
+            SetHandler "proxy:fcgi://{{ php_fpm_listen }}"
           </FilesMatch>
 
   - servername: "pimpmylog.{{ vagrant_hostname }}"
     documentroot: "{{ pimpmylog_install_dir }}"
     extra_parameters: |
           <FilesMatch \.php$>
-            SetHandler "proxy:unix:{{ php_fpm_listen }}|fcgi://pimpmylog.{{ vagrant_hostname }}/"
+            SetHandler "proxy:fcgi://{{ php_fpm_listen }}"
           </FilesMatch>
 
   - servername: "{{ vagrant_ip }}"
@@ -136,7 +136,7 @@ apache_vhosts:
     documentroot: "{{ dashboard_install_dir }}"
     extra_parameters: |
           <FilesMatch \.php$>
-            SetHandler "proxy:unix:{{ php_fpm_listen }}|fcgi://dashboard.{{ vagrant_hostname }}/"
+            SetHandler "proxy:fcgi://{{ php_fpm_listen }}"
           </FilesMatch>
 
 apache_remove_default_vhost: true
@@ -261,7 +261,7 @@ php_max_input_vars: "4000"
 # to instead use Apache + mod_php with an Ubuntu base box, make sure you add
 # libapache2-mod-php7.0 to `extra_packages` elsewhere in this config file.
 php_enable_php_fpm: true
-php_fpm_listen: /var/run/php-fpm.sock
+php_fpm_listen: "127.0.0.1:9000"
 
 composer_path: /usr/bin/composer
 composer_home_path: "/home/{{ drupalvm_user }}/.composer"

--- a/default.config.yml
+++ b/default.config.yml
@@ -98,6 +98,13 @@ drupalvm_cron_jobs: []
 # this variable is 'true'.
 configure_drush_aliases: true
 
+# Helper variable to configure the PHP-FPM connection for each Apache
+# VirtualHost in the `apache_vhosts` list.
+apache_vhost_php_fpm_parameters: |
+    <FilesMatch \.php$>
+      SetHandler "proxy:fcgi://{{ php_fpm_listen }}"
+    </FilesMatch>
+
 # Apache VirtualHosts. Add one for each site you are running inside the VM. For
 # multisite deployments, you can point multiple servernames at one documentroot.
 # View the geerlingguy.apache Ansible Role README for more options.
@@ -105,39 +112,24 @@ apache_vhosts:
   - servername: "{{ drupal_domain }}"
     serveralias: "www.{{ drupal_domain }}"
     documentroot: "{{ drupal_core_path }}"
-    extra_parameters: |
-          <FilesMatch \.php$>
-            SetHandler "proxy:fcgi://{{ php_fpm_listen }}"
-          </FilesMatch>
+    extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"
 
   - servername: "adminer.{{ vagrant_hostname }}"
     documentroot: "{{ adminer_install_dir }}"
-    extra_parameters: |
-          <FilesMatch \.php$>
-            SetHandler "proxy:fcgi://{{ php_fpm_listen }}"
-          </FilesMatch>
+    extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"
 
   - servername: "xhprof.{{ vagrant_hostname }}"
     documentroot: "{{ php_xhprof_html_dir }}"
-    extra_parameters: |
-          <FilesMatch \.php$>
-            SetHandler "proxy:fcgi://{{ php_fpm_listen }}"
-          </FilesMatch>
+    extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"
 
   - servername: "pimpmylog.{{ vagrant_hostname }}"
     documentroot: "{{ pimpmylog_install_dir }}"
-    extra_parameters: |
-          <FilesMatch \.php$>
-            SetHandler "proxy:fcgi://{{ php_fpm_listen }}"
-          </FilesMatch>
+    extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"
 
   - servername: "{{ vagrant_ip }}"
     serveralias: "dashboard.{{ vagrant_hostname }}"
     documentroot: "{{ dashboard_install_dir }}"
-    extra_parameters: |
-          <FilesMatch \.php$>
-            SetHandler "proxy:fcgi://{{ php_fpm_listen }}"
-          </FilesMatch>
+    extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"
 
 apache_remove_default_vhost: true
 apache_mods_enabled:

--- a/default.config.yml
+++ b/default.config.yml
@@ -161,6 +161,7 @@ nginx_hosts:
 
   - server_name: "{{ vagrant_ip }} dashboard.{{ vagrant_hostname }}"
     root: "{{ dashboard_install_dir }}"
+    is_php: true
 
 nginx_remove_default_vhost: true
 nginx_ppa_use: true

--- a/provisioning/templates/nginx-vhost.conf.j2
+++ b/provisioning/templates/nginx-vhost.conf.j2
@@ -17,7 +17,7 @@ server {
 {% if item.is_php is defined and item.is_php %}
     location / {
         # Don't touch PHP for static content.
-        try_files $uri /index.php?$query_string;
+        try_files $uri $uri/ /index.php?$query_string;
     }
 
     # Don't allow direct access to PHP files in the vendor directory.

--- a/provisioning/templates/nginx-vhost.conf.j2
+++ b/provisioning/templates/nginx-vhost.conf.j2
@@ -34,7 +34,7 @@ server {
         fastcgi_intercept_errors on;
         fastcgi_read_timeout {{ php_max_execution_time }};
         include fastcgi_params;
-        fastcgi_pass unix:{{ php_fpm_listen }};
+        fastcgi_pass {{ php_fpm_listen }};
     }
 
     location @rewrite {

--- a/provisioning/templates/nginx-vhost.conf.j2
+++ b/provisioning/templates/nginx-vhost.conf.j2
@@ -34,7 +34,7 @@ server {
         fastcgi_intercept_errors on;
         fastcgi_read_timeout {{ php_max_execution_time }};
         include fastcgi_params;
-        fastcgi_pass {{ php_fpm_listen }};
+        fastcgi_pass unix:{{ php_fpm_listen }};
     }
 
     location @rewrite {

--- a/provisioning/templates/nginx-vhost.conf.j2
+++ b/provisioning/templates/nginx-vhost.conf.j2
@@ -26,6 +26,11 @@ server {
         return 404;
     }
 
+    # Redirect common PHP files to their new locations.
+    location ~ ^((?!.*(?:core)).*)/(install.php|rebuild.php) {
+         return 301 $scheme://$host$1/core/$2$is_args$args;
+    }
+
     # Use fastcgi for all php files.
     location ~ \.php$|^/update.php {
         fastcgi_split_path_info ^(.+?\.php)(|/.*)$;


### PR DESCRIPTION
Adding the PR for travis as well as further review and discussion.

- [x] Both dashboard index.html and php_info.php work.
- [x] Default Drupal installation works
  _Status reports only complaint is that trusted hosts settings is disabled._
- [x] Ensure index.html files are used as `DirectoryIndex` #617
  _Added Zen and http://drupalvm.dev/themes/contrib/zen/STARTERKIT/styleguide/ displays `index.html`_
- [x] Fix: Drupal core redirects fail on fresh installation #1055
  > curl -I http://drupalvm.dev/install.php
HTTP/1.1 301 Moved Permanently
  > 
- [x] Drupal 8 not recognizing clean url support #945
  _Adding `install_site: false` and running the installation through `/install.php` adds the `rewrite=ok` GET parameter._