### PR TITLE
Fix nginx bad gateway errors

### DIFF
--- a/provisioning/templates/nginx-vhost.conf.j2
+++ b/provisioning/templates/nginx-vhost.conf.j2
@@ -40,6 +40,8 @@ server {
         fastcgi_read_timeout {{ php_max_execution_time }};
         include fastcgi_params;
         fastcgi_pass {{ php_fpm_listen }};
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
     }
 
     location @rewrite {


### PR DESCRIPTION
I experienced this on a client site so it is pretty hard to add reproducing steps but the idea is if you have a page that needs a higher fastcgi buffer size you get a 502 error "Bad Gateway" from nginx.

This took a while to track back down but I isolated it to adding these two lines to the nginx-vhost.conf.j2 file.

NOTE: I expect there will be changes to this before it is merged.  These settings match Pantheon's settings so maybe they should be configurable in config.yml instead of directly adding them to this file?  I do think that a default setting for these could be higher though, so that it just works out of the box.