### PR TITLE
Adding an option to enable the gui in the vagrant box...

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -160,7 +160,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # HGFS kernel module currently doesn't load correctly for native shares.
     override.vm.synced_folder host_project_dir, '/vagrant', type: 'nfs'
 
-    v.gui = false
+    v.gui = vconfig['vagrant_gui']
     v.vmx['memsize'] = vconfig['vagrant_memory']
     v.vmx['numvcpus'] = vconfig['vagrant_cpus']
   end
@@ -173,6 +173,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.cpus = vconfig['vagrant_cpus']
     v.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
     v.customize ['modifyvm', :id, '--ioapic', 'on']
+    v.gui = vconfig['vagrant_gui']
   end
 
   # Parallels.

--- a/default.config.yml
+++ b/default.config.yml
@@ -4,6 +4,7 @@
 vagrant_box: geerlingguy/ubuntu1604
 vagrant_user: vagrant
 vagrant_synced_folder_default_type: nfs
+vagrant_gui: false
 
 # If you need to run multiple instances of Drupal VM, set a unique hostname,
 # machine name, and IP address for each instance.


### PR DESCRIPTION
... for times when developers might not want a headless box.

Hi Jeff! 
Thanks for the drupal-vm, it's great!
I'm working with a team who are on old-ish Windows machines, and would rather work inside a Linux VM with a desktop, which requires enabling the gui the Vagrant options.
This allows that, while keeping the default option to headless.
Any chance it would be useful to merge in?
Cheers,
FInn