### PR TITLE
Indicate "less than" version constraint with "<"

### DIFF
--- a/docs/configurations/base-os.md
+++ b/docs/configurations/base-os.md
@@ -32,7 +32,7 @@ Everything should work out of the box with RHEL 7.
 
 **Apache without FastCGI**: If you want to use Apache with CentOS 6 on Drupal VM, you will need to modify the syntax of your `apache_vhosts` and remove the `extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"` line from each one. Alternatively, you can use Nginx with the default configuration by setting `drupalvm_webserver: nginx` inside `config.yml`.
 
-**PHP OpCache**: PHP's OpCache (if you're using PHP > 5.5) requires the following setting to be configured in `config.yml` (see upstream bug: [CentOS (6) needs additional php-opcache package](https://github.com/geerlingguy/ansible-role-php/issues/39)):
+**PHP OpCache**: PHP's OpCache (if you're using PHP < 5.5) requires the following setting to be configured in `config.yml` (see upstream bug: [CentOS (6) needs additional php-opcache package](https://github.com/geerlingguy/ansible-role-php/issues/39)):
 
 ```yaml
 php_opcache_enabled_in_ini: false


### PR DESCRIPTION
Currently, it uses a "greater than" sign (">").