### PR TITLE
Add note about firewalld on CentOS 6

### DIFF
--- a/docs/configurations/base-os.md
+++ b/docs/configurations/base-os.md
@@ -30,10 +30,15 @@ Everything should work out of the box with RHEL 7.
 
 ## RedHat Enterprise Linux / CentOS 6
 
-**Apache without FastCGI**: If you want to use Apache with CentOS 6 on Drupal VM, you will need to modify the syntax of your `apache_vhosts` and remove the `extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"` line from each one. Alternatively, you can use Nginx with the default configuration by setting `drupalvm_webserver: nginx` inside `config.yml`.
+- **Apache without FastCGI**: If you want to use Apache with CentOS 6 on Drupal VM, you will need to modify the syntax of your `apache_vhosts` and remove the `extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"` line from each one. Alternatively, you can use Nginx with the default configuration by setting `drupalvm_webserver: nginx` inside `config.yml`.
 
-**PHP OpCache**: PHP's OpCache (if you're using PHP > 5.5) requires the following setting to be configured in `config.yml` (see upstream bug: [CentOS (6) needs additional php-opcache package](https://github.com/geerlingguy/ansible-role-php/issues/39)):
+- **PHP OpCache**: PHP's OpCache (if you're using PHP > 5.5) requires the following setting to be configured in `config.yml` (see upstream bug: [CentOS (6) needs additional php-opcache package](https://github.com/geerlingguy/ansible-role-php/issues/39)):
 
-```yaml
-php_opcache_enabled_in_ini: false
-```
+  ```yaml
+  php_opcache_enabled_in_ini: false
+  ```
+
+- **Firewalld**: [Firewalld](http://www.firewalld.org/) is not available on CentOS 6, so the Drupal VM setting `firewall_disable_firewalld`, which defaults to `true`, must be overridden in `config.yml` and set to `false`:
+  ```yaml
+  firewall_disable_firewalld: false
+  ```

--- a/docs/configurations/base-os.md
+++ b/docs/configurations/base-os.md
@@ -34,11 +34,12 @@ Everything should work out of the box with RHEL 7.
 
 - **PHP OpCache**: PHP's OpCache (if you're using PHP > 5.5) requires the following setting to be configured in `config.yml` (see upstream bug: [CentOS (6) needs additional php-opcache package](https://github.com/geerlingguy/ansible-role-php/issues/39)):
 
-  ```yaml
-  php_opcache_enabled_in_ini: false
-  ```
+```yaml
+php_opcache_enabled_in_ini: false
+```
 
 - **Firewalld**: [Firewalld](http://www.firewalld.org/) is not available on CentOS 6, so the Drupal VM setting `firewall_disable_firewalld`, which defaults to `true`, must be overridden in `config.yml` and set to `false`:
-  ```yaml
-  firewall_disable_firewalld: false
-  ```
+
+```yaml
+firewall_disable_firewalld: false
+```


### PR DESCRIPTION
Since firewalld does not exist for CentOS 6, the Drupal VM `firewall_disable_firewalld` setting, which defaults to `true`, must be overridden in `config.yml` and set to `false`.

Also, this commit organizes the CentOS 6 notes into bullets.