### PR TITLE
Use VAGRANT_HOME to get ssh key directory

### DIFF
--- a/provisioning/templates/drupalvm.aliases.drushrc.php.j2
+++ b/provisioning/templates/drupalvm.aliases.drushrc.php.j2
@@ -13,7 +13,7 @@ $aliases['{{ host }}'] = array(
   'root' => '{{ root }}',
   'remote-host' => '{{ host }}',
   'remote-user' => '{{ vagrant_user }}',
-  'ssh-options' => '-o PasswordAuthentication=no -i ' . drush_server_home() . '/.vagrant.d/insecure_private_key',
+  'ssh-options' => '-o PasswordAuthentication=no -i "' . (getenv('VAGRANT_HOME') ?: drush_server_home() . '/.vagrant.d') . '/insecure_private_key"',
   'path-aliases' => array(
     '%drush-script' => '{{ drush_path }}',
   ),


### PR DESCRIPTION
Fixes having a VAAGRANT_HOME set to a different directory.