### PR TITLE
Issue #1220: Fix to ensure www-data is in the same group as NFS synced dirs

### DIFF
--- a/provisioning/tasks/www.yml
+++ b/provisioning/tasks/www.yml
@@ -4,24 +4,60 @@
     path: /vagrant
   register: vagrant_directory
 
-- name: Detect if group used to sync directories already exist.
-  shell: "getent group {{ vagrant_directory.stat.gid }} | cut -d':' -f1"
-  register: vagrant_directory_groupname
-  when: vagrant_directory.stat.exists
-
-- name: Ensure a group with the same GID as used to sync directories exist.
+# When using NFS the group id of a folder will be identical to that of the host
+# machine, but the groupname will differ or not exist. For the latter case
+# we create a group called `vagrant_group`.
+#
+# In Ansible 2.3+ the gr_name will be set if the GID is mapped to an existing
+# group. If the GID doesn't exist, gr_name will be undefined.
+- name: Ensure a group with the same GID as used to sync directories exist (Ansible 2.3+).
   group:
     gid: "{{ vagrant_directory.stat.gid }}"
     name: vagrant_group
     state: present
-  when: vagrant_directory.stat.exists and vagrant_directory_groupname.stdout == ''
+  when: >
+    ansible_version.full | version_compare('2.3', '>=') and
+    vagrant_directory.stat.exists and
+    vagrant_directory.stat.gr_name is undefined
 
-- name: Ensure www-data user is in the same group as the owner of synced directories.
+- name: Ensure the webserver user is in the same group as the owner of synced directories (Ansible 2.3+).
+  user:
+    name: www-data
+    append: yes
+    groups: "{{ vagrant_directory.stat.gr_name|default('vagrant_group') }}"
+  when: >
+    ansible_version.full | version_compare('2.3', '>=') and
+    vagrant_directory.stat.exists
+
+# With Ansible 2.2 or lower, the existance of gr_name is dependant on the
+# existance of UID as well, therefore we cannot rely on it.
+# TODO: Remove the version compares and the 2.2 tasks once we require Ansible
+# 2.3+
+- name: Detect if group used to sync directories already exist (Ansible 2.2).
+  shell: "getent group {{ vagrant_directory.stat.gid }} | cut -d':' -f1"
+  register: vagrant_directory_groupname
+  when: >
+    ansible_version.full | version_compare('2.3', '<') and
+    vagrant_directory.stat.exists
+
+- name: Ensure a group with the same GID as used to sync directories exist (Ansible 2.2).
+  group:
+    gid: "{{ vagrant_directory.stat.gid }}"
+    name: vagrant_group
+    state: present
+  when: >
+    ansible_version.full | version_compare('2.3', '<') and
+    vagrant_directory.stat.exists and
+    vagrant_directory_groupname.stdout == ''
+
+- name: Ensure the webserver user is in the same group as the owner of synced directories (Ansible 2.2).
   user:
     name: www-data
     append: yes
     groups: "{{ vagrant_directory_groupname.stdout|default('vagrant_group') }}"
-  when: vagrant_directory.stat.exists
+  when: >
+    ansible_version.full | version_compare('2.3', '<') and
+    vagrant_directory.stat.exists
 
 - name: Ensure admin group exist.
   group: "name=admin state=present"

--- a/provisioning/tasks/www.yml
+++ b/provisioning/tasks/www.yml
@@ -47,6 +47,7 @@
 - name: Detect if group used to sync directories already exist (Ansible 2.2).
   shell: "getent group {{ vagrant_directory.stat.gid }} | cut -d':' -f1"
   register: vagrant_directory_groupname
+  changed_when: false
   when: >
     ansible_version.full | version_compare('2.3', '<') and
     vagrant_directory.stat.exists

--- a/provisioning/tasks/www.yml
+++ b/provisioning/tasks/www.yml
@@ -37,7 +37,8 @@
     groups: "{{ vagrant_directory.stat.gr_name|default('vagrant_group') }}"
   when: >
     ansible_version.full | version_compare('2.3', '>=') and
-    vagrant_directory.stat.exists
+    vagrant_directory.stat.exists and
+    not (vagrant_directory.stat.gr_name is defined and vagrant_directory.stat.gr_name == 'root')
 
 # With Ansible 2.2 or lower, the existance of gr_name is dependant on the
 # existance of UID as well, therefore we cannot rely on it.
@@ -67,7 +68,8 @@
     groups: "{{ vagrant_directory_groupname.stdout|default('vagrant_group') }}"
   when: >
     ansible_version.full | version_compare('2.3', '<') and
-    vagrant_directory.stat.exists
+    vagrant_directory.stat.exists and
+    vagrant_directory_groupname.stdout != 'root'
 
 - name: Ensure admin group exist.
   group: "name=admin state=present"

--- a/provisioning/tasks/www.yml
+++ b/provisioning/tasks/www.yml
@@ -1,19 +1,33 @@
 ---
-# Originally I tried adding to the www group, but because Ansible uses one SSH
-# connection, that broke the initial provisioning, since groups aren't refreshed
-# without a new session or log off/log on.
-- name: Ensure necessary groups exist.
-  group: "name={{ item }} state=present"
-  with_items:
-    - admin
-    - dialout
+- name: Register information about the /vagrant directory.
+  stat:
+    path: /vagrant
+  register: vagrant_directory
+
+- name: Detect if group used to sync directories already exist.
+  shell: "getent group {{ vagrant_directory.stat.gid }} | cut -d':' -f1"
+  register: vagrant_directory_groupname
+  when: vagrant_directory.stat.exists
+
+- name: Ensure a group with the same GID as used to sync directories exist.
+  group:
+    gid: "{{ vagrant_directory.stat.gid }}"
+    name: vagrant_group
+    state: present
+  when: vagrant_directory.stat.exists and vagrant_directory_groupname.stdout == ''
+
+- name: Ensure www-data user is in the same group as the owner of synced directories.
+  user:
+    name: www-data
+    append: yes
+    groups: "{{ vagrant_directory_groupname.stdout|default('vagrant_group') }}"
+  when: vagrant_directory.stat.exists
+
+- name: Ensure admin group exist.
+  group: "name=admin state=present"
 
 - name: Ensure vagrant user is in admin group.
   user: "name={{ vagrant_user }} append=yes groups=admin"
-
-- name: Ensure www-data user is in dialout group (Debian).
-  user: "name=www-data append=yes groups=dialout"
-  when: ansible_os_family == 'Debian'
 
 - name: Set nicer permissions on Apache log directory.
   file:

--- a/provisioning/tasks/www.yml
+++ b/provisioning/tasks/www.yml
@@ -1,4 +1,14 @@
 ---
+- name: Define drupalvm_webserver_user (Debian).
+  set_fact:
+    drupalvm_webserver_user: www-data
+  when: ansible_os_family == 'Debian' and drupalvm_webserver_user is undefined
+
+- name: Define drupalvm_webserver_user (RedHat).
+  set_fact:
+    drupalvm_webserver_user: "{{ (drupalvm_webserver == 'apache') | ternary('httpd', 'nginx') }}"
+  when: ansible_os_family == 'RedHat' and drupalvm_webserver_user is undefined
+
 - name: Register information about the /vagrant directory.
   stat:
     path: /vagrant
@@ -22,7 +32,7 @@
 
 - name: Ensure the webserver user is in the same group as the owner of synced directories (Ansible 2.3+).
   user:
-    name: www-data
+    name: "{{ drupalvm_webserver_user }}"
     append: yes
     groups: "{{ vagrant_directory.stat.gr_name|default('vagrant_group') }}"
   when: >
@@ -52,7 +62,7 @@
 
 - name: Ensure the webserver user is in the same group as the owner of synced directories (Ansible 2.2).
   user:
-    name: www-data
+    name: "{{ drupalvm_webserver_user }}"
     append: yes
     groups: "{{ vagrant_directory_groupname.stdout|default('vagrant_group') }}"
   when: >


### PR DESCRIPTION
This is still WIP. Not the nicest solution and it needs proper testing.

Using `stat.gr_name` would be way nicer and could remove the shell task, unfortunately I can't get this to work though. It's never defined in my case.

Also, if the user sets `vagrant_synced_folder_default_type` to something other than `nfs` while using `nfs` for the primary synced folder, this wont help. Other than that I don't see this causing issues. Maybe with smb somehow?