### PR TITLE
Follow-up #1213: Add support for DRUPALVM_ANSIBLE_TAGS env variable

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -151,6 +151,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       drupalvm_env: drupalvm_env
     }
     ansible.raw_arguments = ENV['DRUPALVM_ANSIBLE_ARGS']
+    ansible.tags = ENV['DRUPALVM_ANSIBLE_TAGS']
   end
 
   # VMware Fusion.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,6 +64,19 @@ ansible_bin = which('ansible-playbook')
 ansible_version = Gem::Version.new(get_ansible_version(ansible_bin)) if ansible_bin
 ansible_version_min = Gem::Version.new(vconfig['drupalvm_ansible_version_min'])
 
+if ansible_bin && ansible_version < ansible_version_min
+  raise "You must update Ansible to at least #{ansible_version_min} to use this version of Drupal VM."
+end
+
+provisioner = ansible_bin && !vconfig['force_ansible_local'] ? :ansible : :ansible_local
+if provisioner == :ansible
+  playbook = "#{host_drupalvm_dir}/provisioning/playbook.yml"
+  config_dir = host_config_dir
+else
+  playbook = "#{guest_drupalvm_dir}/provisioning/playbook.yml"
+  config_dir = guest_config_dir
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Networking configuration.
   config.vm.hostname = vconfig['vagrant_hostname']
@@ -131,28 +144,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Allow override of the default synced folder type.
   config.vm.synced_folder host_project_dir, '/vagrant', type: vconfig.include?('vagrant_synced_folder_default_type') ? vconfig['vagrant_synced_folder_default_type'] : 'nfs'
 
-  # Provisioning. Use ansible if it's installed, ansible_local if not or if forced.
-  if ansible_bin && !vconfig['force_ansible_local']
-    if ansible_version < ansible_version_min
-      raise "You must update Ansible to at least #{ansible_version_min} to use this version of Drupal VM."
-    end
-    config.vm.provision 'ansible' do |ansible|
-      ansible.playbook = "#{host_drupalvm_dir}/provisioning/playbook.yml"
-      ansible.extra_vars = {
-        config_dir: host_config_dir,
-        drupalvm_env: drupalvm_env
-      }
-      ansible.raw_arguments = ENV['DRUPALVM_ANSIBLE_ARGS']
-    end
-  else
-    config.vm.provision 'ansible_local' do |ansible|
-      ansible.playbook = "#{guest_drupalvm_dir}/provisioning/playbook.yml"
-      ansible.extra_vars = {
-        config_dir: guest_config_dir,
-        drupalvm_env: drupalvm_env
-      }
-      ansible.raw_arguments = ENV['DRUPALVM_ANSIBLE_ARGS']
-    end
+  config.vm.provision provisioner do |ansible|
+    ansible.playbook = playbook
+    ansible.extra_vars = {
+      config_dir: config_dir,
+      drupalvm_env: drupalvm_env
+    }
+    ansible.raw_arguments = ENV['DRUPALVM_ANSIBLE_ARGS']
   end
 
   # VMware Fusion.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,10 +64,6 @@ ansible_bin = which('ansible-playbook')
 ansible_version = Gem::Version.new(get_ansible_version(ansible_bin)) if ansible_bin
 ansible_version_min = Gem::Version.new(vconfig['drupalvm_ansible_version_min'])
 
-if ansible_bin && ansible_version < ansible_version_min
-  raise "You must update Ansible to at least #{ansible_version_min} to use this version of Drupal VM."
-end
-
 provisioner = ansible_bin && !vconfig['force_ansible_local'] ? :ansible : :ansible_local
 if provisioner == :ansible
   playbook = "#{host_drupalvm_dir}/provisioning/playbook.yml"
@@ -75,6 +71,10 @@ if provisioner == :ansible
 else
   playbook = "#{guest_drupalvm_dir}/provisioning/playbook.yml"
   config_dir = guest_config_dir
+end
+
+if provisioner == :ansible && ansible_version < ansible_version_min
+  raise "You must update Ansible to at least #{ansible_version_min} to use this version of Drupal VM."
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/docs/extending/ansible-args.md
+++ b/docs/extending/ansible-args.md
@@ -1,3 +1,15 @@
+## Run a specific set of tagged tasks
+
+You can filter which part of the provisioning process to run by specifying a set of tags using the `DRUPALVM_ANSIBLE_TAGS` environment variable.
+
+```sh
+# E.g. xdebug, drupal, webserver, database, cron...
+DRUPALVM_ANSIBLE_TAGS=xdebug vagrant provision
+
+# Or combine them (e.g. if adding new databases and virtualhosts).
+DRUPALVM_ANSIBLE_TAGS=webserver,database vagrant provision
+```
+
 ## Passing arguments to ansible during a provision
 
 You can specify an additional argument to the `ansible-playbook` command by using the `DRUPALVM_ANSIBLE_ARGS` environment variable. This can be useful when debugging a task failure.
@@ -6,16 +18,6 @@ You can specify an additional argument to the `ansible-playbook` command by usin
 >
 >   - Passing more than one argument may require special formatting. Read the [Ansible provisioner's `raw_arguments` docs](https://www.vagrantup.com/docs/provisioning/ansible_common.html#raw_arguments) for more info.
 >   - You should not quote a flag's value as you would normally do in the shell.
-
-Run a specific set of tagged tasks:
-
-```sh
-# E.g. xdebug, drupal, webserver, database, cron...
-DRUPALVM_ANSIBLE_ARGS='--tags=xdebug' vagrant provision
-
-# Or combine them (e.g. if adding new databases and virtualhosts).
-DRUPALVM_ANSIBLE_ARGS='--tags=webserver,database' vagrant provision
-```
 
 Display verbose ansible output:
 


### PR DESCRIPTION
I refactored the provisioner declaration so that it's more DRY. Doesnt matter much now but maybe if we add SKIP_TAGS or some more config variables in the future.