### PR TITLE
Issue #1199: Fix synced folder examples in docs

### DIFF
--- a/docs/getting-started/syncing-folders.md
+++ b/docs/getting-started/syncing-folders.md
@@ -26,13 +26,11 @@ One scenario where this might be useful is when you are moving generated code fr
 
 ```yaml
 options_override:
-  # Disable the default recursive chown so that the files/ folder won't be affected
-  rsync__chown: false
+  rsync__owner: vagrant
+  rsync__group: www-data
   rsync__args: [
     "--verbose", "--archive", "--delete",
     "--chmod=gu=rwX,o=rX", # 664 for files, 775 for directories
-    "--owner", "--group", # required for the following command
-    "--usermap=*:vagrant", "--groupmap=*:www-data"
   ]
 ```
 

--- a/docs/getting-started/syncing-folders.md
+++ b/docs/getting-started/syncing-folders.md
@@ -69,9 +69,9 @@ If you're encountering errors where Drupal or some other software inside the VM 
 vagrant_synced_folders:
   - local_path: .
     destination: /var/www/drupalvm
-    type: nfs
+    type: ""
     create: true
-    mount_options: ["dmode=775,fmode=664"]
+    mount_options: ["dmode=775", "fmode=664"]
     options_override:
       owner: "vagrant"
       group: "www-data"


### PR DESCRIPTION
While reading through the synced folder docs I also tested out one of the examples that seemed incorrect. NFS does not support `dmode` or `fmode`, and produces an invalid mount command. Also `owner`/`group` doesn't affect NFS.