### PR TITLE
Raise a VagrantError rather than a RuntimeError for clearer message

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,7 +74,7 @@ else
 end
 
 if provisioner == :ansible && ansible_version < ansible_version_min
-  raise "You must update Ansible to at least #{ansible_version_min} to use this version of Drupal VM."
+  raise Vagrant::Errors::VagrantError.new, "You must update Ansible to at least #{ansible_version_min} to use this version of Drupal VM."
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|


### PR DESCRIPTION
I thought this was nicer and less confusing, what do you think?

old

```sh
$ vagrant status
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: /Users/cindy/Projects/Personal/drupal-vm/Vagrantfile
Line number: 77
Message: RuntimeError: You must update Ansible to at least 2.2 to use this version of Drupal VM.
```

new

```sh
$ vagrant status
You must update Ansible to at least 2.2 to use this version of Drupal VM.
```