### PR TITLE
Add an intro message for vagrant up/reload

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -99,6 +99,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Vagrant box.
   config.vm.box = vconfig['vagrant_box']
 
+  unless vconfig['vagrant_skip_post_up_message']
+    config.vm.post_up_message = 'Your Drupal VM Vagrant box is ready to use!'\
+      "\n* Visit the dashboard for an overview of your site: http://dashboard.#{vconfig['vagrant_hostname']} (or http://#{vconfig['vagrant_ip']})"\
+      "\n* You can SSH into your machine with `vagrant ssh`."\
+      "\n* Find out more in the Drupal VM documentation at http://docs.drupalvm.com"
+  end
+
   # If a hostsfile manager plugin is installed, add all server names as aliases.
   aliases = []
   if vconfig['drupalvm_webserver'] == 'apache'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -99,7 +99,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Vagrant box.
   config.vm.box = vconfig['vagrant_box']
 
-  unless vconfig['vagrant_skip_post_up_message']
+  if vconfig.include?('vagrant_post_up_message')
+    config.vm.post_up_message = vconfig['vagrant_post_up_message']
+  else
     config.vm.post_up_message = 'Your Drupal VM Vagrant box is ready to use!'\
       "\n* Visit the dashboard for an overview of your site: http://dashboard.#{vconfig['vagrant_hostname']} (or http://#{vconfig['vagrant_ip']})"\
       "\n* You can SSH into your machine with `vagrant ssh`."\


### PR DESCRIPTION
Just posting ideas...

```sh
==> drupalvm_project: Mounting NFS shared folders...
==> drupalvm_project: Mounting shared folders...
    drupalvm_project: /var/www/drupalvm => /Users/cindy/Projects/Personal/drupal-vm
==> drupalvm_project: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> drupalvm_project: flag to force provisioning. Provisioners marked to run always will still run.

==> drupalvm_project: Machine 'drupalvm_project' has a post `vagrant up` message. This is a message
==> drupalvm_project: from the creator of the Vagrantfile, and not from Vagrant itself:
==> drupalvm_project:
==> drupalvm_project: Your Drupal VM Vagrant box is ready to use!
==> drupalvm_project: * Visit the dashboard for an overview of your site: http://dashboard.drupalvm-project.dev (or http://192.168.99.88)
==> drupalvm_project: * You can SSH into your machine with `vagrant ssh`.
==> drupalvm_project: * Find out more in the Drupal VM documentation at http://docs.drupalvm.com
```