### PR TITLE
Read [host-os].config.yml if available

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -20,6 +20,7 @@
         - "{{ config_dir }}/config.yml"
         - "{{ config_dir }}/local.config.yml"
         - "{{ config_dir }}/secrets.yml"
+        - "{{ config_dir }}/{{ drupalvm_host_os|default(ansible_system.lower()) }}.config.yml"
         - "{{ config_dir }}/{{ lookup('env', 'DRUPALVM_ENV')|default(drupalvm_env, true)|default(ansible_env.DRUPALVM_ENV)|default(omit) }}.config.yml"
       tags: ['always']
 


### PR DESCRIPTION
Toyed around with an idea and thought I'd post it for feedback or future reference. This would try and load a host os specific config file so that teams could provide a `windows.config.yml` with

```yaml
vagrant_synced_folder_default_type: "smb"
vagrant_synced_folders:
  - local_path: .
    destination: /var/www/drupal
    type: smb
    create: true
```

Very untested.