### PR TITLE
Fix Ansible 2.3 not purging PHP packages because of jinja templating in when statement

### DIFF
--- a/provisioning/tasks/init-debian.yml
+++ b/provisioning/tasks/init-debian.yml
@@ -76,7 +76,7 @@
     state: absent
     purge: yes
     force: yes
-  when: "'php{{ php_version }}' not in item"
+  when: "'php' + php_version not in item"
   with_flattened:
     - "{{ php_packages|regex_replace('php' + php_version, 'php5.6') }}"
     - "{{ php_packages|regex_replace('php' + php_version, 'php7.0') }}"


### PR DESCRIPTION
Before:

```
TASK [Purge PHP version packages.] *********************************************
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: 'php{{ php_version }}' not in item
```

After:

```
TASK [Purge PHP version packages.] *********************************************
ok: [drupalvm_project] => (item=[u'php5.6', u'php5.6-apcu', u'php5.6-cli', u'php5.6-common', u'php5.6-curl', u'php5.6-dev', u'php5.6-fpm', u'php5.6-gd', u'php5.6-imap', u'php5.6-json', u'php5.6-mbstring', u'php5.6-mcrypt', u'php5.6-opcache', u'php5.6-sqlite3', u'php5.6-xml', u'php5.6-yaml', u'php7.0', u'php7.0-apcu', u'php7.0-cli', u'php7.0-common', u'php7.0-curl', u'php7.0-dev', u'php7.0-fpm', u'php7.0-gd', u'php7.0-imap', u'php7.0-json', u'php7.0-mbstring', u'php7.0-mcrypt', u'php7.0-opcache', u'php7.0-sqlite3', u'php7.0-xml', u'php7.0-yaml'])
```