### PR TITLE
Issue #1324: Remove geerlingguy.nginx hard dependency from drupalvm.www

### DIFF
--- a/provisioning/roles/drupalvm.www/README.md
+++ b/provisioning/roles/drupalvm.www/README.md
@@ -12,7 +12,7 @@ There are a few defaults defined, but you shouldn't really need to worry about t
 
 ## Dependencies
 
-  - geerlingguy.nginx
+  - geerlingguy.nginx if `drupalvm_webserver` is set to `nginx`.
 
 ## Example Playbook
 

--- a/provisioning/roles/drupalvm.www/meta/main.yml
+++ b/provisioning/roles/drupalvm.www/meta/main.yml
@@ -28,4 +28,4 @@ galaxy_info:
     - vagrant
 
 dependencies:
-  - geerlingguy.nginx
+  - { role: geerlingguy.nginx, when: drupalvm_webserver == 'nginx' }


### PR DESCRIPTION
Or should we use:

```yaml
dependencies:
  - { role: geerlingguy.nginx, when: drupalvm_webserver == 'nginx' }
```