### PR TITLE
Fixes Error Message "Message: LoadError: cannot load such file -- ./l…

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-require './lib/drupalvm/vagrant'
+require_relative 'lib/drupalvm/vagrant'
 
 # Absolute paths on the host machine.
 host_drupalvm_dir = File.dirname(File.expand_path(__FILE__))


### PR DESCRIPTION
Fixes Error Message "Message: LoadError: cannot load such file -- ./lib/drupalvm/vagrant" when running vagrant up or destroy.

In this particular instance, the error arose when using a build similar to that described in the [Composer Dependency](http://docs.drupalvm.com/en/latest/deployment/composer-dependency) documentation.