### PR TITLE
Fixes #1351

### DIFF
--- a/docs/deployment/composer.md
+++ b/docs/deployment/composer.md
@@ -1,13 +1,14 @@
 Drupal VM is configured to use `composer create-project` to build a Drupal 8 codebase by default but supports building Drupal from a custom `composer.json` file as well.
 
 1. Copy `example.drupal.composer.json` to `drupal.composer.json` and modify it to your liking.
-2. Use the Composer build system by setting `drupal_build_composer: true` in your `config.yml` (make sure `drupal_build_makefile` and `build_composer_project` are set to `false`).
-3. Configure `drupal_core_path` to point to the webroot directory: `drupal_core_path: {{ drupal_composer_install_dir }}/docroot`
+2. Use the Composer build system by setting `drupal_build_composer: true` in your `config.yml` (make sure `drupal_build_makefile` and `drupal_build_composer_project` are set to `false`).
+3. Ensure `drupal_core_path` points to the webroot directory: `drupal_core_path: {{ drupal_composer_install_dir }}/web`
 
 ```yaml
+drupal_build_makefile: false
 drupal_build_composer_project: false
 drupal_build_composer: true
-drupal_core_path: "{{ drupal_composer_install_dir }}/docroot"
+drupal_core_path: "{{ drupal_composer_install_dir }}/web"
 ```
 
 _The file set in `drupal_composer_path` (which defaults to `drupal.composer.json`) will be copied from your host computer into the VM's `drupal_composer_install_dir` and renamed `composer.json`._

--- a/example.drupal.composer.json
+++ b/example.drupal.composer.json
@@ -28,10 +28,10 @@
     "prefer-stable": true,
     "extra": {
         "installer-paths": {
-            "docroot/core": ["type:drupal-core"],
-            "docroot/modules/contrib/{$name}": ["type:drupal-module"],
-            "docroot/profiles/contrib/{$name}": ["type:drupal-profile"],
-            "docroot/themes/contrib/{$name}": ["type:drupal-theme"],
+            "web/core": ["type:drupal-core"],
+            "web/modules/contrib/{$name}": ["type:drupal-module"],
+            "web/profiles/contrib/{$name}": ["type:drupal-profile"],
+            "web/themes/contrib/{$name}": ["type:drupal-theme"],
             "drush/contrib/{$name}": ["type:drupal-drush"]
         }
     },


### PR DESCRIPTION
Sets example.composer.json to use "web" directory.
Updates documentation references from "docroot" to "web".