### PR TITLE
Update default node version to 6.x

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -278,8 +278,8 @@ mysql_wait_timeout: 300
 adminer_install_filename: index.php
 
 # Node.js configuration (if enabled above).
-# Valid examples: "0.10", "0.12", "4.x", "5.x".
-nodejs_version: "0.12"
+# Valid examples: "0.10", "0.12", "4.x", "5.x", "6.x".
+nodejs_version: "6.x"
 nodejs_npm_global_packages: []
 nodejs_install_npm_user: "{{ drupalvm_user }}"
 npm_config_prefix: "/home/{{ drupalvm_user }}/.npm-global"


### PR DESCRIPTION
Updating default node version to `6.x` which is the same as the [role default](https://github.com/geerlingguy/drupal-vm/blob/master/provisioning/roles/geerlingguy.nodejs/defaults/main.yml).

Therefore, it could potentially be removed from `default.config.yml` but it might be useful to keep so it exposes the config.

Relates to #1348