### PR TITLE
Encapsulate the documentroot in the vhost template

### DIFF
--- a/provisioning/roles/geerlingguy.apache/templates/vhosts.conf.j2
+++ b/provisioning/roles/geerlingguy.apache/templates/vhosts.conf.j2
@@ -8,7 +8,7 @@
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
 {% if vhost.documentroot is defined %}
-  DocumentRoot {{ vhost.documentroot }}
+  DocumentRoot "{{ vhost.documentroot }}"
 {% endif %}
 
 {% if vhost.serveradmin is defined %}
@@ -42,7 +42,7 @@
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
 {% if vhost.documentroot is defined %}
-  DocumentRoot {{ vhost.documentroot }}
+  DocumentRoot "{{ vhost.documentroot }}"
 {% endif %}
 
   SSLEngine on


### PR DESCRIPTION
The apache2 vhosts' documentroot paths were not encapsulated in quotation marks. This would cause an apache2 startup error for paths with spaces or other restricted characters.