### PR TITLE
Issue #1375: Allow /vagrant synced folder to be overridden

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,6 +75,14 @@ Vagrant.configure('2') do |config|
     config.hostmanager.aliases = aliases
   end
 
+  # Sync the project root directory to /vagrant
+  unless vconfig['vagrant_synced_folders'].any? { |synced_folder| synced_folder['destination'] == '/vagrant' }
+    vconfig['vagrant_synced_folders'].push(
+      'local_path' => host_project_dir,
+      'destination' => '/vagrant'
+    )
+  end
+
   # Synced folders.
   vconfig['vagrant_synced_folders'].each do |synced_folder|
     options = {
@@ -90,9 +98,6 @@ Vagrant.configure('2') do |config|
     end
     config.vm.synced_folder synced_folder.fetch('local_path'), synced_folder.fetch('destination'), options
   end
-
-  # Allow override of the default synced folder type.
-  config.vm.synced_folder host_project_dir, '/vagrant', type: vconfig['vagrant_synced_folder_default_type']
 
   config.vm.provision provisioner do |ansible|
     ansible.playbook = playbook

--- a/docs/getting-started/installation-linux.md
+++ b/docs/getting-started/installation-linux.md
@@ -74,6 +74,30 @@ If encryption is not the issue then it's likely that either NFS isn't running co
 
 After attempting any of the above fixes, run `vagrant reload --provision` to restart the VM and attempt mounting the synced folder again, or `vagrant destroy -f && vagrant up` to rebuild the VM from scratch.
 
+### NFS shares are slow or hang due to UDP protocol
+
+If the default transport protocol UDP is causing slowness or failures to mount NFS shared folders, you can switch to NFSv4 and TCP by configuring your `vagrant_synced_folders` like the example below:
+
+```
+vagrant_synced_folders:
+  # The default share.
+  - local_path: .
+    destination: /var/www/drupalvm
+    type: nfs
+    create: true
+    options_override:
+      nfs_version: 4
+      nfs_udp: false
+
+  # Manually specify the /vagrant share to override the defaults
+  - local_path: .
+    destination: /vagrant
+    type: nfs
+    options_override:
+      nfs_version: 4
+      nfs_udp: false
+```
+
 ## Intel VT-x virtualization support
 
 On some laptops, Intel VT-x virtualization (which is built into most modern Intel processors) is enabled by default. This allows VirtualBox to run virtual machines efficiently using the CPU itself instead of software CPU emulation. If you get a message like "VT-x is disabled in the bios for both all cpu modes" or something similar, you may need to enter your computer's BIOS or UEFI settings and enable this virtualization support.


### PR DESCRIPTION
How about leveraging the same logic as we already use for `vagrant_synced_folders`?

```
vagrant_synced_folders:
  - local_path: .
    destination: /var/www/drupalvm
    type: nfs
    create: true
  - local_path: .
    destination: /vagrant
    type: rsync
    options_override: [...]
```

Would need to add docs for this though.