### PR TITLE
Issue #1370: Add VirtualBox version requirement check

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,6 +39,7 @@ end
 # Verify version requirements.
 require_ansible_version ">= #{vconfig['drupalvm_ansible_version_min']}"
 Vagrant.require_version ">= #{vconfig['drupalvm_vagrant_version_min']}"
+require_virtualbox_version ">= #{vconfig['drupalvm_virtualbox_version_min']}"
 
 Vagrant.configure('2') do |config|
   # Set the name of the VM. See: http://stackoverflow.com/a/17864388/100134

--- a/default.config.yml
+++ b/default.config.yml
@@ -36,6 +36,7 @@ vagrant_cpus: 1
 # Minimum required versions.
 drupalvm_vagrant_version_min: '1.8.6'
 drupalvm_ansible_version_min: '2.2'
+drupalvm_virtualbox_version_min: '5.1.10'
 
 # Force use of ansible_local provisioner, even if Ansible is installed on host.
 force_ansible_local: false

--- a/lib/drupalvm/vagrant.rb
+++ b/lib/drupalvm/vagrant.rb
@@ -55,12 +55,27 @@ def ansible_version
   /^[^\s]+ (.+)$/.match(`#{ansible_bin} --version`) { |match| return match[1] }
 end
 
+def virtualbox_version
+  virtualbox = VagrantPlugins::ProviderVirtualBox::Driver::Meta.new
+  virtualbox.version
+rescue Vagrant::Errors::VirtualBoxNotDetected
+  nil
+end
+
 # Require that if installed, the ansible version meets the requirements.
 def require_ansible_version(requirement)
   return unless ansible_bin
   req = Gem::Requirement.new(requirement)
   return if req.satisfied_by?(Gem::Version.new(ansible_version))
   raise_message "You must install an Ansible version #{requirement} to use this version of Drupal VM."
+end
+
+# Require that if installed, the VirtualBox version meets the requirements.
+def require_virtualbox_version(requirement)
+  return unless virtualbox_version
+  req = Gem::Requirement.new(requirement)
+  return if req.satisfied_by?(Gem::Version.new(virtualbox_version))
+  raise_message "You must install a VirtualBox version #{requirement} to use this version of Drupal VM."
 end
 
 def raise_message(msg)


### PR DESCRIPTION
As I mentioned in #1370, this is not 100% reliable as it enforces the version requirements as long as VirtualBox is available, regardless if the provider is used or not. 

As there's no way to determine the current provider in a `Vagrantfile`, I don't think we can improve this. Feel free to close if you think the false positives outweigh the benefit.