### PR TITLE
Add note about tideways rather than xhprof to default.config.yml

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -218,7 +218,7 @@ installed_extras:
   # - upload-progress
   - varnish
   # - xdebug
-  # - xhprof
+  # - xhprof # use `tideways` if you're installing PHP 7+
 
 # Add any extra apt or yum packages you would like installed.
 extra_packages:


### PR DESCRIPTION
I've been hit by php segfaults due to having XHProf installed on old projects I bump to PHP 7.1.

Also XHProf was the cause for at least these two issues:
- https://github.com/geerlingguy/drupal-vm/issues/1285
- https://github.com/geerlingguy/drupal-vm/issues/1341