### PR TITLE
Issue 1418: Allow default distribution php packages to be used

### DIFF
--- a/docs/configurations/php.md
+++ b/docs/configurations/php.md
@@ -14,3 +14,9 @@ Remi's RPM repository is included with Drupal VM, and you can make the following
 
   1. Make sure you've followed the directions for switching to CentOS 7 in the [use a different base OS](base-os.md) guide.
   2. Change `php_version` inside `config.yml` to `"5.6"` or `"7.0"`.
+
+## Using default distribution packages
+
+If you want parity with your production environment and wish to install the default distribution packages, set `php_version: ''` inside your `config.yml` to avoid adding Remi's or Ondřej's repositories. Doing this will use the default packages set in the [`geerlingguy.php`](https://github.com/geerlingguy/ansible-role-php) Ansible role.
+
+_Note: If you're using a base OS with a PHP version older than what's assumed in the `geerlingguy.php` role, you will also need to override some of the default variables set by that role in your `config.yml`. See the [`geerlingguy.php` Ansible role's README](https://github.com/geerlingguy/ansible-role-php-#readme) for more information._

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -40,7 +40,7 @@
     - { role: geerlingguy.apache, when: drupalvm_webserver == 'apache', tags: ['webserver']}
     - { role: geerlingguy.apache-php-fpm, when: drupalvm_webserver == 'apache', tags: ['webserver'] }
     - { role: geerlingguy.nginx, when: drupalvm_webserver == 'nginx', tags: ['webserver'] }
-    - { role: geerlingguy.php-versions, tags: ['php', 'xdebug', 'database'] }
+    - { role: geerlingguy.php-versions, when: php_version != '', tags: ['php', 'xdebug', 'database'] }
     - { role: geerlingguy.php, tags: ['php'] }
     - { role: geerlingguy.php-pecl, tags: ['php'] }
     - { role: geerlingguy.composer }


### PR DESCRIPTION
Built successfully with this `config.yml` on Ubuntu 16.04:

```yaml
---
php_version: ''

installed_extras:
  - adminer
  - blackfire
  # - drupalconsole
  - drush
  # - elasticsearch
  # - java
  - mailhog
  - memcached
  # - newrelic
  # - nodejs
  - pimpmylog
  - redis
  # - ruby
  # - selenium
  # - solr
  - tideways
  - upload-progress
  - varnish
  - xdebug
  # - xhprof # use `tideways` if you're installing PHP 7+
```

That last sentence in the docs might need some tuning.