### PR TITLE
Update comment in Solr post-provisioning script

### DIFF
--- a/examples/scripts/configure-solr.sh
+++ b/examples/scripts/configure-solr.sh
@@ -4,7 +4,7 @@
 #
 # This script configures the default Apache Solr search core to use one of the
 # Drupal Solr module's configurations. This shell script presumes you have
-# `solr` in the `installed_extras`, and is currently set up for the D7 versions
+# `solr` in the `installed_extras`, and is currently set up for the D8 versions
 # of Apache Solr Search or Search API Solr.
 
 SOLR_CORE_NAME="d8"


### PR DESCRIPTION
Still says it is set up for D7, but is set up for D8.