### PR TITLE
Add default directory for `vagrant exec` commands.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -152,6 +152,10 @@ Vagrant.configure('2') do |config|
       type: vconfig['vagrant_synced_folder_default_type']
     }
   end
+  
+  if Vagrant.has_plugin?('vagrant-exec')
+    config.exec.commands '*', directory: vconfig['drupal_composer_install_dir']
+  end
 
   # Allow an untracked Vagrantfile to modify the configurations
   [host_config_dir, host_project_dir].uniq.each do |dir|


### PR DESCRIPTION
This PR adds support for the Vagrant Exec plugin.

By default, using `vagrant exec [command]` will execute a command in the `/vagrant` dir on the VM. This can be problematic for a variety of reasons. 

In short, `/vagrant` isn't the directory that is considered the "drupal" directory. We should use `drupal_composer_install_dir` instead.

This PR will not affect users that do not use Vagrant Exec.
