### PR TITLE
Issue #1437: Add support for list of paths in pre/post_provision_tasks_dir

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -25,8 +25,7 @@
       include: "{{ outer_item }}"
       loop_control:
         loop_var: outer_item
-      with_fileglob:
-        - "{{ pre_provision_tasks_dir|default(omit) }}"
+      with_fileglob: "{{ pre_provision_tasks_dir|default(omit) }}"
 
     - include: tasks/php.yml
 
@@ -128,5 +127,4 @@
       include: "{{ outer_item }}"
       loop_control:
         loop_var: outer_item
-      with_fileglob:
-        - "{{ post_provision_tasks_dir|default(omit) }}"
+      with_fileglob: "{{ post_provision_tasks_dir|default(omit) }}"


### PR DESCRIPTION
Might need testing in older versions of Ansible but at least as of 2.3.1.0 this has backwards compatibility. This is also what we added to [`geerlingguy.mac-dev-playbook`](https://github.com/geerlingguy/mac-dev-playbook/pull/43/files) btw.