### PR TITLE
Fix outdated comment for drupal_install_site variable

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -82,7 +82,7 @@ drupal_db_user: drupal
 drupal_db_password: drupal
 drupal_db_name: drupal
 
-# Settings for installing a Drupal site if 'install_site:' is 'true'.
+# Settings for installing a Drupal site if 'drupal_install_site:' is 'true'.
 drupal_major_version: 8
 drupal_domain: "{{ vagrant_hostname }}"
 drupal_site_name: "Drupal"


### PR DESCRIPTION
Just found the outdated comment in `default.config.yml`.
The variable has been renamed in #1193 