### PR TITLE
Use absolute paths for example post_provision_scripts

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -280,11 +280,12 @@ composer_home_group: "{{ drupalvm_user }}"
 composer_global_packages:
   - { name: hirak/prestissimo, release: '^0.3' }
 
-# Run specified scripts before or after VM is provisioned. Path is relative to
-# the `provisioning/playbook.yml` file.
+# Run specified scripts before or after VM is provisioned. Use {{ playbook_dir }}
+# to reference the provisioning/ folder in Drupal VM or {{ config_dir }} to
+# reference the directory where your `config.yml` is.
 pre_provision_scripts: []
 post_provision_scripts: []
-  # - "../examples/scripts/configure-solr.sh"
+  # - "{{ playbook_dir }}/../examples/scripts/configure-solr.sh"
 
 # MySQL Configuration.
 mysql_root_password: root

--- a/docs/deployment/composer-dependency.md
+++ b/docs/deployment/composer-dependency.md
@@ -45,16 +45,6 @@ If you intened to use the devel module, it must be added as a requirement to you
 drupal_enabled_modules: []
 ```
 
-If you're using `pre_provision_scripts` or `post_provision_scripts` you also need to adjust their paths to take into account the new directory structure. The examples used in `default.config.yml` assume the files are located in the Drupal VM directory. You can use the `config_dir` variable which is the absolute path of the directory where your `config.yml` is located.
-
-```yaml
-post_provision_scripts:
-  # The default provided in `default.config.yml`:
-  - "../../examples/scripts/configure-solr.sh"
-  # With Drupal VM as a Composer dependency:
-  - "{{ config_dir }}/../examples/scripts/configure-solr.sh"
-```
-
 ### Create a delegating `Vagrantfile`
 
 Create a delegating `Vagrantfile` that will catch all your `vagrant` commands and send them to Drupal VM's own `Vagrantfile`. Place this file in your project's root directory.


### PR DESCRIPTION
I think knowing about `{{ playbook_dir }}` and `{{ config_dir }}` makes it easier for users to reason about the paths. Counting parent directories is a headache.