### PR TITLE
Enable linked_clone on versions greater than 1.8.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -124,7 +124,7 @@ Vagrant.configure('2') do |config|
 
   # VirtualBox.
   config.vm.provider :virtualbox do |v|
-    v.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+    v.linked_clone = true
     v.name = vconfig['vagrant_hostname']
     v.memory = vconfig['vagrant_memory']
     v.cpus = vconfig['vagrant_cpus']


### PR DESCRIPTION
Linked clones are only enabled on vagrant versions `1.8.x`, updates to enable of all versions greater than `1.8`