### PR TITLE
Support alternatives when auto-installing plugins

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -43,7 +43,9 @@ vagrant_cpus: 1
 # Ensure vagrant plugins are installed.
 vagrant_plugins:
   - name: vagrant-vbguest
-  - name: vagrant-hostsupdater
+  - alternatives:
+    - name: vagrant-hostsupdater
+    - name: vagrant-hostmanager
 
 # Minimum required versions.
 drupalvm_vagrant_version_min: '1.8.6'


### PR DESCRIPTION
Fixes issue #1548.

DrupalVM auto-installs plugins by default. The problem I face is with `vagrant-hostsupdate` which I don't really need (I use `vagrant-hostmanager` which works well). But since it auto-installs, I need to remember to either remove it from default.config.yml or override it if I am using a composer setup. This is quite irritating.

What is ideal is to allow specifying alternative plugins. I have a PR ready for that. Since Ruby isn't my first language, I would appreciate some code review. I believe it can be done in a much better way than what I have tried. I have tested my changes and they work.