### PR TITLE
Support vagrant DHCP IP assignment with `vagrant-hostmanager`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,15 +55,7 @@ Vagrant.configure('2') do |config|
 
     # Use assigned IP with vagrant-hostmanager
     if Vagrant.has_plugin?('vagrant-hostmanager')
-      cached_addresses = {}
-      config.hostmanager.ip_resolver = proc do |vm, _resolving_vm|
-        if cached_addresses[vm.name].nil? && vm.communicate.ready?
-          vm.communicate.execute("hostname -I | cut -d ' ' -f 2") do |_type, contents|
-            cached_addresses[vm.name] = contents.split("\n").first[/(\d+\.\d+\.\d+\.\d+)/, 1]
-          end
-        end
-        cached_addresses[vm.name]
-      end
+      config.hostmanager.ip_resolver = vagrant_ip_resolver
     end
   elsif vconfig['vagrant_ip'] == '0.0.0.0' && Vagrant.has_plugin?('vagrant-auto_network')
     # Use vagrant-auto_network to assign IP automatically

--- a/lib/drupalvm/vagrant.rb
+++ b/lib/drupalvm/vagrant.rb
@@ -72,6 +72,18 @@ def vagrant_provisioner
   ansible_bin ? :ansible : :ansible_local
 end
 
+def vagrant_ip_resolver
+  cached_addresses = {}
+  proc do |vm, _resolving_vm|
+    if cached_addresses[vm.name].nil? && vm.communicate.ready?
+      vm.communicate.execute("hostname -I | cut -d ' ' -f 2") do |_type, contents|
+        cached_addresses[vm.name] = contents.split("\n").first[/(\d+\.\d+\.\d+\.\d+)/, 1]
+      end
+    end
+    cached_addresses[vm.name]
+  end
+end
+
 def ensure_plugins(plugins)
   logger = Vagrant::UI::Colored.new
   installed = false

--- a/provisioning/templates/dashboard.html.j2
+++ b/provisioning/templates/dashboard.html.j2
@@ -21,7 +21,7 @@
   </head>
   <body>
     {# Sets vagrant IP if equals 0.0.0.0 #}
-    {%- if vagrant_ip == '0.0.0.0' -%}
+    {%- if vagrant_ip == '0.0.0.0' or vagrant_ip == 'dhcp' -%}
       {%- set vagrant_ip = ansible_all_ipv4_addresses[1] -%}
     {%- endif -%}
     {# Returns the hosts server name based on the document root #}


### PR DESCRIPTION
See https://github.com/geerlingguy/drupal-vm/issues/1548#issuecomment-330365797.

This needs to be thoroughly tested but in my opinion this classifies as a _"compelling technical reason"_ for a switch to `vagrant-hostmanager`.

- If `vagrant_ip` is set to the new default `dhcp`, the VM will be assigned an IP with DHCP and configured using `vagrant-hostmanager`.
- If a static IP is set, it will be kept but `vagrant-hostmanager` will be installed and used instead.
- If `0.0.0.0` is used, `vagrant-auto_network` will continue to be used.

This is what my hosts file looks like after bringing up two new VMs:

```
192.168.88.88  drupalvm.test  # VAGRANT: a97adfc1a53d882e0a42473a42d1ec66 (drupalvm) / ec047028-5e0a-49fd-bd7a-f0472f127d6c
192.168.88.88  www.drupalvm.test  # VAGRANT: a97adfc1a53d882e0a42473a42d1ec66 (drupalvm) / ec047028-5e0a-49fd-bd7a-f0472f127d6c
192.168.88.88  adminer.drupalvm.test  # VAGRANT: a97adfc1a53d882e0a42473a42d1ec66 (drupalvm) / ec047028-5e0a-49fd-bd7a-f0472f127d6c
192.168.88.88  xhprof.drupalvm.test  # VAGRANT: a97adfc1a53d882e0a42473a42d1ec66 (drupalvm) / ec047028-5e0a-49fd-bd7a-f0472f127d6c
192.168.88.88  pimpmylog.drupalvm.test  # VAGRANT: a97adfc1a53d882e0a42473a42d1ec66 (drupalvm) / ec047028-5e0a-49fd-bd7a-f0472f127d6c
192.168.88.88  dashboard.drupalvm.test  # VAGRANT: a97adfc1a53d882e0a42473a42d1ec66 (drupalvm) / ec047028-5e0a-49fd-bd7a-f0472f127d6c

## vagrant-hostmanager-start id: 507bfe16-8e86-4df9-b21a-fcac1af63073
172.28.128.3	drupalvm-two.test
172.28.128.3	www.drupalvm-two.test
172.28.128.3	adminer.drupalvm-two.test
172.28.128.3	xhprof.drupalvm-two.test
172.28.128.3	pimpmylog.drupalvm-two.test
172.28.128.3	dashboard.drupalvm-two.test
## vagrant-hostmanager-end

## vagrant-hostmanager-start id: 80c4c10c-3b29-4c0c-b0f1-91aa3b4e0811
172.28.128.4	drupalvm-foo.test
172.28.128.4	www.drupalvm-foo.test
172.28.128.4	adminer.drupalvm-foo.test
172.28.128.4	xhprof.drupalvm-foo.test
172.28.128.4	pimpmylog.drupalvm-foo.test
172.28.128.4	dashboard.drupalvm-foo.test
## vagrant-hostmanager-end
```

It's noteworthy to mention that `vagrant-hostmanager` doesn't clean up the host entries when you run `vagrant halt`. They're only cleared out on `vagrant destroy` which is a better behavior as the IP wont change constantly.

@hussainweb also mentioned

> The reason I use hostmanager is that it is more feature complete. It manages hosts entries on both host and guest (all guests), and I like how it adds entries in blocks in the hosts file which makes it easier to manage manually if I have to.

If we decide to go with this, [geerlingguy.mac-dev-playbook](https://github.com/geerlingguy/mac-dev-playbook) also needs to be updated for passwordless commands.