### PR TITLE
Improve debug output in travis

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -51,10 +51,15 @@ fi
 # Set OS-specific options.
 if [[ "$OSTYPE" == "darwin"* ]]; then
   volume_opts='rw,cached'
-  xargs_command='xargs'
 else
   volume_opts='rw'
+fi
+
+# Use correct xargs command depending if it's GNU or BSD.
+if xargs --version 2>&1 | grep -s GNU >/dev/null; then
   xargs_command='xargs -r'
+else
+  xargs_command='xargs'
 fi
 
 # Exit on any individual command failure.

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -115,53 +115,60 @@ fi
 # Drupal.
 printf "\n"${green}"Running functional tests..."${neutral}"\n"
 docker exec $CONTAINER_ID curl -s --header Host:$HOSTNAME localhost \
+  | tee /tmp/dvm-test \
   | grep -q '<title>Welcome to Drupal' \
   && (echo 'Drupal install pass' && exit 0) \
-  || (echo 'Drupal install fail' && exit 1)
+  || (echo 'Drupal install fail' && cat /tmp/dvm-test && exit 1)
 
 # Adminer.
 if [ $TEST_INSTALLED_EXTRAS = true ]; then
   docker exec $CONTAINER_ID curl -s --header Host:adminer.$HOSTNAME localhost \
+    | tee /tmp/dvm-test \
     | grep -q '<title>Login - Adminer' \
     && (echo 'Adminer install pass' && exit 0) \
-    || (echo 'Adminer install fail' && exit 1)
+    || (echo 'Adminer install fail' && cat /tmp/dvm-test && exit 1)
 fi
 
 # Pimp My Log.
 if [ $TEST_INSTALLED_EXTRAS = true ]; then
   docker exec $CONTAINER_ID curl -s --header Host:pimpmylog.$HOSTNAME localhost \
+    | tee /tmp/dvm-test \
     | grep -q '<title>Pimp my Log' \
     && (echo 'Pimp my Log install pass' && exit 0) \
-    || (echo 'Pimp my Log install fail' && exit 1)
+    || (echo 'Pimp my Log install fail' && cat /tmp/dvm-test && exit 1)
 fi
 
 # MailHog.
 if [ $TEST_INSTALLED_EXTRAS = true ]; then
   docker exec $CONTAINER_ID curl -s localhost:8025 \
+    | tee /tmp/dvm-test \
     | grep -q '<title>MailHog' \
     && (echo 'MailHog install pass' && exit 0) \
-    || (echo 'MailHog install fail' && exit 1)
+    || (echo 'MailHog install fail' && cat /tmp/dvm-test && exit 1)
 fi
 
 # Varnish.
 if [ $TEST_INSTALLED_EXTRAS = true ]; then
   docker exec $CONTAINER_ID curl -sI --header Host:$HOSTNAME localhost:81 \
+    | tee /tmp/dvm-test \
     | grep -q 'Via: .* varnish' \
     && (echo 'Varnish install pass' && exit 0) \
-    || (echo 'Varnish install fail' && exit 1)
+    || (echo 'Varnish install fail' && cat /tmp/dvm-test && exit 1)
 fi
 
 # Dashboard.
 docker exec $CONTAINER_ID curl -s --header Host:$IP localhost \
+  | tee /tmp/dvm-test \
   | grep -q "<li>$IP $HOSTNAME</li>" \
   && (echo 'Dashboard install pass' && exit 0) \
-  || (echo 'Dashboard install fail' && exit 1)
+  || (echo 'Dashboard install fail' && cat /tmp/dvm-test && exit 1)
 
 # Drush.
 docker exec $CONTAINER_ID $DRUSH_BIN @$MACHINE_NAME.$HOSTNAME status \
+  | tee /tmp/dvm-test \
   | grep -q 'Drupal bootstrap.*Successful' \
   && (echo 'Drush install pass' && exit 0) \
-  || (echo 'Drush install fail' && exit 1)
+  || (echo 'Drush install fail' && cat /tmp/dvm-test && exit 1)
 
 # Remove test container.
 printf "\n"${green}"Cleaning up..."${neutral}"\n"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -114,7 +114,7 @@ fi
 
 # Drupal.
 printf "\n"${green}"Running functional tests..."${neutral}"\n"
-docker exec $CONTAINER_ID curl -s --header Host:$HOSTNAME localhost \
+docker exec $CONTAINER_ID curl -sSi --header Host:$HOSTNAME localhost \
   | tee /tmp/dvm-test \
   | grep -q '<title>Welcome to Drupal' \
   && (echo 'Drupal install pass' && exit 0) \
@@ -122,7 +122,7 @@ docker exec $CONTAINER_ID curl -s --header Host:$HOSTNAME localhost \
 
 # Adminer.
 if [ $TEST_INSTALLED_EXTRAS = true ]; then
-  docker exec $CONTAINER_ID curl -s --header Host:adminer.$HOSTNAME localhost \
+  docker exec $CONTAINER_ID curl -sSi --header Host:adminer.$HOSTNAME localhost \
     | tee /tmp/dvm-test \
     | grep -q '<title>Login - Adminer' \
     && (echo 'Adminer install pass' && exit 0) \
@@ -131,7 +131,7 @@ fi
 
 # Pimp My Log.
 if [ $TEST_INSTALLED_EXTRAS = true ]; then
-  docker exec $CONTAINER_ID curl -s --header Host:pimpmylog.$HOSTNAME localhost \
+  docker exec $CONTAINER_ID curl -sSi --header Host:pimpmylog.$HOSTNAME localhost \
     | tee /tmp/dvm-test \
     | grep -q '<title>Pimp my Log' \
     && (echo 'Pimp my Log install pass' && exit 0) \
@@ -140,7 +140,7 @@ fi
 
 # MailHog.
 if [ $TEST_INSTALLED_EXTRAS = true ]; then
-  docker exec $CONTAINER_ID curl -s localhost:8025 \
+  docker exec $CONTAINER_ID curl -sSi localhost:8025 \
     | tee /tmp/dvm-test \
     | grep -q '<title>MailHog' \
     && (echo 'MailHog install pass' && exit 0) \
@@ -149,7 +149,7 @@ fi
 
 # Varnish.
 if [ $TEST_INSTALLED_EXTRAS = true ]; then
-  docker exec $CONTAINER_ID curl -sI --header Host:$HOSTNAME localhost:81 \
+  docker exec $CONTAINER_ID curl -sSI --header Host:$HOSTNAME localhost:81 \
     | tee /tmp/dvm-test \
     | grep -q 'Via: .* varnish' \
     && (echo 'Varnish install pass' && exit 0) \
@@ -157,7 +157,7 @@ if [ $TEST_INSTALLED_EXTRAS = true ]; then
 fi
 
 # Dashboard.
-docker exec $CONTAINER_ID curl -s --header Host:$IP localhost \
+docker exec $CONTAINER_ID curl -sSi --header Host:$IP localhost \
   | tee /tmp/dvm-test \
   | grep -q "<li>$IP $HOSTNAME</li>" \
   && (echo 'Dashboard install pass' && exit 0) \

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -15,6 +15,7 @@ TEST_INSTALLED_EXTRAS="${TEST_INSTALLED_EXTRAS:-true}"
 CONTAINER_ID="${CONTAINER_ID:-dvm-test}"
 type="${type:-tests/defaults}"
 distro="${distro:-ubuntu1604}"
+cleanup="${cleanup:-true}"
 
 ## Set up vars for Docker setup.
 # CentOS 7
@@ -171,6 +172,11 @@ docker exec $CONTAINER_ID $DRUSH_BIN @$MACHINE_NAME.$HOSTNAME status \
   || (echo 'Drush install fail' && cat /tmp/dvm-test && exit 1)
 
 # Remove test container.
-printf "\n"${green}"Cleaning up..."${neutral}"\n"
-docker rm -f $CONTAINER_ID
-printf ${green}"...done!"${neutral}"\n\n"
+if [ $cleanup = true ]; then
+  printf "\n"${green}"Cleaning up..."${neutral}"\n"
+  docker rm -f $CONTAINER_ID
+  printf ${green}"...done!"${neutral}"\n\n"
+else
+  printf "\n"${green}"Skipping cleanup for container id: ${CONTAINER_ID}!"${neutral}"\n"
+  printf ${green}"Done!"${neutral}"\n\n"
+fi


### PR DESCRIPTION
Print body and headers if a test fails. Let's see what mailhog says.

- `-i` show headers in output
- `-I` fetch headers only
- `-s` hide progress bar (and error messages unless `-S`)
- `-S` show error messages.