### PR TITLE
php_xdebug_cli_enable is unused

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -319,7 +319,7 @@ pimpmylog_grant_all_privs: true
 # XDebug configuration. XDebug is disabled by default for better performance.
 php_xdebug_default_enable: 0
 php_xdebug_coverage_enable: 0
-php_xdebug_cli_enable: 1
+php_xdebug_cli_disable: yes
 php_xdebug_remote_enable: 1
 php_xdebug_remote_connect_back: 1
 # Use PHPSTORM for PHPStorm, sublime.xdebug for Sublime Text.


### PR DESCRIPTION
This is a follow up to https://github.com/geerlingguy/ansible-role-php-xdebug/pull/47

As indicated in that issue, `php_xdebug_cli_enable` is no longer used and references to it should be removed.

However, it's being replaced by a new option `php_xdebug_cli_disable` in https://github.com/geerlingguy/ansible-role-php-xdebug/pull/54. So it might make sense to just switch one for the other.