### PR TITLE
Update broken link to Drupal Console documentation

### DIFF
--- a/docs/extras/drupal-console.md
+++ b/docs/extras/drupal-console.md
@@ -35,7 +35,7 @@ Execute from host machine using the `--target` option.
 
     drupal --target=drupalvm.test site:status
 
-For more details, see [Drupal Console's documentation](https://hechoendrupal.gitbooks.io/drupal-console/content/en/using/how-to-use-drupal-console-in-a-remote-installation.html)
+For more details, see [Drupal Console's documentation](https://docs.drupalconsole.com/en/alias/how-to-use-drupal-console-in-a-remote-installation.html)
 
 For a list of available role variables, see the [`geerlingguy.drupal-console` Ansible role's README](https://github.com/geerlingguy/ansible-role-drupal-console#readme).
 


### PR DESCRIPTION
Discovered a link to Drupal Console's old documentation that no longer worked. Found the most relevant page in the current documentation.