### PR TITLE
Changed the default mysql user privileges

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -192,7 +192,7 @@ mysql_users:
   - name: "{{ drupal_db_user }}"
     host: "%"
     password: "{{ drupal_db_password }}"
-    priv: "{{ drupal_db_name }}.*:ALL"
+    priv: "{{ drupal_db_name }}%.*:ALL"
 
 # PostgreSQL databases and users.
 postgresql_databases:


### PR DESCRIPTION
Add a % to the default mysql user privileges to all for database prefixing.

I understand that this is likely not everyone's workflow. I create a new database for each feature branch that I work on. I have a script that I put in my settings.local.php that detects the git branch that I am working on and adds a suffix to the db table name. I already override this on my local config.yml but thought that I would bring it up as a change because I find it very useful and it isn't a breaking change.

As an example if I am working on a feature branch ```2.2.x-some-feature``` then the db my drupalvm install uses is ```drupalvm-2-2-x-some-feature```. Using ```drush sql-create``` and ```drush sql-sync``` I am able to quickly switch to new features while maintaining the work that was done on old features.