### PR TITLE
Added name to Ansible provisioner in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -102,7 +102,7 @@ Vagrant.configure('2') do |config|
     config.vm.synced_folder synced_folder.fetch('local_path'), synced_folder.fetch('destination'), options
   end
 
-  config.vm.provision provisioner do |ansible|
+  config.vm.provision "drupalvm", type: "ansible"  do |ansible|
     ansible.playbook = playbook
     ansible.extra_vars = {
       config_dir: config_dir,


### PR DESCRIPTION
Vagrant >= 1.7 allows provisioners to be named meaning they can be targeted by name with `--provision-with` rather than just by type (e.g. `ansible`).

This PR allows Drupal VM's Ansible provisioner to be targeted specifically if desired:

```
# Just provision with Drupal VM in isolation
vagrant provision --provision-with drupalvm

# Jump to my "otherprovisioner", don't provision with drupalvm
vagrant provision --provision-with otherprovisioner
```

I've been using Drupal VM with an additional Vagrantfile and multiple additional provisioners and being able to run a single provisioner in isolation has been very useful when debugging.