### PR TITLE
Move SSH tasks in pre_tasks session

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -28,6 +28,7 @@
       with_fileglob: "{{ pre_provision_tasks_dir|default(omit) }}"
 
     - include: tasks/php.yml
+    - include: tasks/sshd.yml
 
   roles:
     # Essential roles.
@@ -103,7 +104,6 @@
     - { role: geerlingguy.security, when: extra_security_enabled }
 
   tasks:
-    - include: tasks/sshd.yml
     - include: tasks/extras.yml
 
     - include: tasks/apparmor.yml


### PR DESCRIPTION
When you develop your own modules and they are hosted in a private repository, you want to add your known_hosts before launching the drush make, or the vagrant process simply goes in timeout