### PR TITLE
Add beet/box as an available base box.

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -1,6 +1,6 @@
 ---
 # Available `vagrant_box` values include:
-#   - beet/box
+#   - beet/box (pre-provisioned, based on Ubuntu 16.04)
 #   - geerlingguy/centos7
 #   - geerlingguy/centos6
 #   - geerlingguy/debian9

--- a/default.config.yml
+++ b/default.config.yml
@@ -1,5 +1,6 @@
 ---
 # Available `vagrant_box` values include:
+#   - beet/box
 #   - geerlingguy/centos7
 #   - geerlingguy/centos6
 #   - geerlingguy/debian9


### PR DESCRIPTION
The base box has been adjusted to work with Drupal VM so provisioning tasks will skip is they've been preprovisioned.. 