### PR TITLE
Update NPM by default

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -298,7 +298,8 @@ adminer_install_filename: index.php
 # Node.js configuration (if enabled above).
 # Valid examples: "0.10", "0.12", "4.x", "5.x", "6.x".
 nodejs_version: "6.x"
-nodejs_npm_global_packages: []
+nodejs_npm_global_packages:
+  - name: npm
 nodejs_install_npm_user: "{{ drupalvm_user }}"
 npm_config_prefix: "/home/{{ drupalvm_user }}/.npm-global"
 


### PR DESCRIPTION
Normally, the NPM version installed by Node out of the box is pretty out of date.

This PR will cause it to automatically be updated to the latest available version (respective to whatever version of Node you are using). This is recommended and considered best practice by Node/NPM.
  