### PR TITLE
Update mkdocs.yml to fix typo

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,7 @@ pages:
     - 'ruby': 'extras/ruby.md'
     - 'selenium (BDD with Behat)': 'extras/selenium.md'
     - 'solr (Search engine)': 'extras/solr.md'
-    - 'tidways (Profiling tool)': 'extras/tideways.md'
+    - 'tideways (Profiling tool)': 'extras/tideways.md'
     - 'upload-progress': 'extras/upload-progress.md'
     - 'varnish (Caching reverse proxy)': 'extras/varnish.md'
     - 'xdebug (Debugging tool)': 'extras/xdebug.md'


### PR DESCRIPTION
Menu item should be "tideways" rather than "tidways"