### PR TITLE
Selenium paths value needs to be quoted

### DIFF
--- a/docs/extras/selenium.md
+++ b/docs/extras/selenium.md
@@ -34,7 +34,7 @@ Using the default Drupal site as an example (it's installed in `/var/www/drupalv
         default:
           suites:
             web_features:
-              paths: [ %paths.base%/features/web ]
+              paths: [ "%paths.base%/features/web" ]
               contexts:
                 - WebContext
                 - Drupal\DrupalExtension\Context\DrupalContext


### PR DESCRIPTION
With behat 3.4.3, the example config gives the following error on behat --init:

The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 4 (near "paths: [ %paths.base%/features/web ]").

This is fixed by quoting the paths value.