### PR TITLE
Make ansible version parsing compatible with releases from git repository

### DIFF
--- a/lib/drupalvm/vagrant.rb
+++ b/lib/drupalvm/vagrant.rb
@@ -52,7 +52,7 @@ end
 
 # Return the ansible version parsed from running the executable path provided.
 def ansible_version
-  /^[^\s]+ (.+)$/.match(`#{ansible_bin} --version`) { |match| return match[1] }
+  /^[^\s]+ ([^\(]+).*$/.match(`#{ansible_bin} --version`) { |match| return match[1] }
 end
 
 # Require that if installed, the ansible version meets the requirements.


### PR DESCRIPTION
When ansible is installed from repository version string is like: 

`ansible 2.4.3.0 (stable-2.4 8708105616) `

Instead of:

`ansible 2.4.3.0`

Regexp fails because it includes the part in parenthesis. Added new regexp that ignores that part. See http://rubular.com/r/J4TBshh16b to see it working.