### PR TITLE
Improve Ansible version detection regexp to stick to Semver.

### DIFF
--- a/lib/drupalvm/vagrant.rb
+++ b/lib/drupalvm/vagrant.rb
@@ -52,7 +52,7 @@ end
 
 # Return the ansible version parsed from running the executable path provided.
 def ansible_version
-  /^[^\s]+ ([^\(]+).*$/.match(`#{ansible_bin} --version`) { |match| return match[1] }
+  /^[^\s]+ ((?:\d\.){2}\d).*$/.match(`#{ansible_bin} --version`) { |match| return match[1] }
 end
 
 # Require that if installed, the ansible version meets the requirements.


### PR DESCRIPTION
This fixes issues with OSX and sticks to Semver (three numbers with dots between).

See issue comment https://github.com/geerlingguy/drupal-vm/issues/1725#issuecomment-374626675

