### PR TITLE
Allow Solr version argument to configure script

### DIFF
--- a/examples/scripts/configure-solr.sh
+++ b/examples/scripts/configure-solr.sh
@@ -17,6 +17,11 @@ SOLR_MODULE_NAME="search_api_solr"
 SOLR_VERSION="5.x"
 SOLR_CORE_PATH="/var/solr/data/$SOLR_CORE_NAME"
 
+# Check to see if version argument specified.
+if [ ! -z "$1" ]; then
+  SOLR_VERSION=$1
+fi
+
 # Check to see if we've already performed this setup.
 if [ ! -e "$SOLR_SETUP_COMPLETE_FILE" ]; then
   # Download and expand the Solr module.


### PR DESCRIPTION
Allowing the version argument will reduce the need to copy and modify the script.