### PR TITLE
Feature/ssh home override of drush site alias

### DIFF
--- a/provisioning/tasks/sshd.yml
+++ b/provisioning/tasks/sshd.yml
@@ -37,6 +37,6 @@
     state: present
     create: yes
     regexp: "^SSH_HOME="
-    line: "SSH_HOME={{ ssh_home }} && [ -e $SSH_HOME ] && cd $SSH_HOME"
+    line: "SSH_HOME=\"{{ ssh_home }}\" && [ -e \"$SSH_HOME\" ] && cd \"$SSH_HOME\""
   become: no
   when: ssh_home is defined

--- a/provisioning/tasks/sshd.yml
+++ b/provisioning/tasks/sshd.yml
@@ -37,6 +37,6 @@
     state: present
     create: yes
     regexp: "^SSH_HOME="
-    line: "SSH_HOME=\"{{ ssh_home }}\" && [[ -e \"$SSH_HOME\" ]] && cd \"$SSH_HOME\""
+    line: "SSH_HOME=\"{{ ssh_home }}\" && [[ -e \"$SSH_HOME\" ]] && [[ \"$PWD\" = \"$HOME\" ]] && cd \"$SSH_HOME\""
   become: no
   when: ssh_home is defined

--- a/provisioning/tasks/sshd.yml
+++ b/provisioning/tasks/sshd.yml
@@ -37,6 +37,6 @@
     state: present
     create: yes
     regexp: "^SSH_HOME="
-    line: "SSH_HOME=\"{{ ssh_home }}\" && [ -e \"$SSH_HOME\" ] && cd \"$SSH_HOME\""
+    line: "SSH_HOME=\"{{ ssh_home }}\" && [[ -e \"$SSH_HOME\" ]] && cd \"$SSH_HOME\""
   become: no
   when: ssh_home is defined


### PR DESCRIPTION
### Proposed Change

Prevent changing directory to the `ssh_home` when an ssh command has already changed the working directory. This prevents override of a Drush site-alias root when a user executes `drush @site-alias ssh`.

Also includes the suggested bash scripting improvements:

* Prevent word splitting in bash variable assignments and comparisons
* Prevent word splitting and filename expansion in bash test command constructs 

### References

* http://tldp.org/LDP/abs/html/testconstructs.html#DBLBRACKETS

### Related Issues

* Fixes #1730 
