### PR TITLE
Remove check for certificate

### DIFF
--- a/provisioning/roles/geerlingguy.apache/tasks/configure-Debian.yml
+++ b/provisioning/roles/geerlingguy.apache/tasks/configure-Debian.yml
@@ -23,11 +23,6 @@
   with_items: "{{ apache_mods_disabled }}"
   notify: restart apache
 
-- name: Check whether certificates defined in vhosts exist.
-  stat: "path={{ item.certificate_file }}"
-  register: apache_ssl_certificates
-  with_items: "{{ apache_vhosts_ssl }}"
-
 - name: Add apache vhosts configuration.
   template:
     src: "{{ apache_vhosts_template }}"

--- a/provisioning/roles/geerlingguy.apache/tasks/configure-RedHat.yml
+++ b/provisioning/roles/geerlingguy.apache/tasks/configure-RedHat.yml
@@ -8,11 +8,6 @@
   with_items: "{{ apache_ports_configuration_items }}"
   notify: restart apache
 
-- name: Check whether certificates defined in vhosts exist.
-  stat: path={{ item.certificate_file }}
-  register: apache_ssl_certificates
-  with_items: "{{ apache_vhosts_ssl }}"
-
 - name: Add apache vhosts configuration.
   template:
     src: "{{ apache_vhosts_template }}"

--- a/provisioning/roles/geerlingguy.apache/tasks/configure-Suse.yml
+++ b/provisioning/roles/geerlingguy.apache/tasks/configure-Suse.yml
@@ -8,11 +8,6 @@
   with_items: "{{ apache_ports_configuration_items }}"
   notify: restart apache
 
-- name: Check whether certificates defined in vhosts exist.
-  stat: path={{ item.certificate_file }}
-  register: apache_ssl_certificates
-  with_items: "{{ apache_vhosts_ssl }}"
-
 - name: Add apache vhosts configuration.
   template:
     src: "{{ apache_vhosts_template }}"

--- a/provisioning/roles/geerlingguy.apache/templates/vhosts.conf.j2
+++ b/provisioning/roles/geerlingguy.apache/templates/vhosts.conf.j2
@@ -52,8 +52,13 @@
 {% if apache_vhosts_version == "2.4" %}
   SSLCompression off
 {% endif %}
+{% if vhost.certificate_file is defined %}
   SSLCertificateFile {{ vhost.certificate_file }}
+{% endif %}
+{% if vhost.certificate_key_file is defined %}
   SSLCertificateKeyFile {{ vhost.certificate_key_file }}
+{% endif %}
+
 {% if vhost.certificate_chain_file is defined %}
   SSLCertificateChainFile {{ vhost.certificate_chain_file }}
 {% endif %}


### PR DESCRIPTION
I've got many sites going and there is a terrible amount of duplication in my `local.config.yml`

The only difference between `apache_vhosts` and `apache_vhosts_ssl` in my case is the `certificate_file` and `certificate_key_file` variables.

With this change you can do this:
```
apache_vhosts_ssl: "{{ apache_vhosts }}"
```

And put the `certificate_file`/`certificate_key_file` in the server config (also default proxy handling):
```
apache_global_vhost_settings: |
  <FilesMatch \.php$>
    SetHandler "proxy:fcgi://{{ php_fpm_listen }}"
  </FilesMatch>

  User vagrant
  Group games

  # Global SSL certificate.
  SSLCertificateFile {{ certificate_file }}
  SSLCertificateKeyFile {{ certificate_key_file }}
```
