### PR TITLE
Change include_tasks to import_tasks for always tasks.

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -7,10 +7,10 @@
     - ../default.config.yml
 
   pre_tasks:
-    - include_tasks: tasks/config.yml
+    - import_tasks: tasks/config.yml
       tags: ['always']
 
-    - include_tasks: tasks/backwards-compatibility.yml
+    - import_tasks: tasks/backwards-compatibility.yml
       tags: ['always']
 
     - include_tasks: "tasks/init-{{ ansible_os_family }}.yml"


### PR DESCRIPTION
Tags don't seem to be inherited with `include_tasks` so switch to `import_tasks` to work on #1835