### PR TITLE
Fixed typo in build-composer.yml that caused composer install to fail

### DIFF
--- a/provisioning/roles/geerlingguy.drupal/tasks/build-composer.yml
+++ b/provisioning/roles/geerlingguy.drupal/tasks/build-composer.yml
@@ -25,7 +25,7 @@
   composer:
     command: install
     working_dir: "{{ drupal_composer_install_dir }}"
-  when: falset drupal_site_exists
+  when: not drupal_site_exists
   become: false
 
 - name: Install dependencies with composer require (this may take a while).


### PR DESCRIPTION
A bug was introduced in commit e8664798e08421db9fc85edfadaf7958750a8907 that causes composer install to fail when drupalVM was added as a dependency to an existing site.