### PR TITLE
fix #1858

### DIFF
--- a/provisioning/tasks/extras.yml
+++ b/provisioning/tasks/extras.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install extra apt packages (if any are configured).
-  apt: "name={{ extra_packages | list }} state=present"
+  apt: "name={{ extra_packages }} state=present"
   when:
     - ansible_os_family == 'Debian'
     - extra_packages | length


### PR DESCRIPTION
it seems that the ```name={{ extra_packages | list }}``` line is not correctly interpreted