### PR TITLE
fixes a problem with WSL vagrant ssh

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -62,6 +62,7 @@ Vagrant.configure('2') do |config|
   # SSH options.
   config.ssh.insert_key = false
   config.ssh.forward_agent = true
+  config.ssh.extra_args = "-tt"
 
   # Vagrant box.
   config.vm.box = vconfig['vagrant_box']


### PR DESCRIPTION
Please review, it's unknown if adding this to the Vagrant config will negativity affect other OSs, but it does fix this specific WSL problem. 

WSL `vagrant.exe ssh` doesn't provide a command prompt/never logs in, adding this argument to the Vagrant file fixes this problem. See: https://github.com/hashicorp/vagrant/issues/9143#issuecomment-401088752