### PR TITLE
Install pip for compatibility with Vagrant ^2.2.5

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -109,6 +109,7 @@ Vagrant.configure('2') do |config|
   end
 
   config.vm.provision 'drupalvm', type: provisioner do |ansible|
+    ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/get-pip.py | sudo python"
     ansible.compatibility_mode = '2.0'
     ansible.playbook = playbook
     ansible.extra_vars = {


### PR DESCRIPTION
Initially running `vagrant up` gave me the following error:

```
    drupal-cms: Installing pip... (for Ansible installation)
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

pip install  --upgrade ansible

Stdout from the command:



Stderr from the command:

bash: line 5: pip: command not found
```

This led me to https://github.com/hashicorp/vagrant/issues/9584 and https://github.com/hashicorp/vagrant/issues/10950#issuecomment-514023810. The following change fixed it for me.