### PR TITLE
Include php_xdebug_version in default.config.yml

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -319,6 +319,7 @@ pimpmylog_install_dir: /usr/share/php/pimpmylog
 pimpmylog_grant_all_privs: true
 
 # XDebug configuration. XDebug is disabled by default for better performance.
+# php_xdebug_version: 2.6.0
 php_xdebug_default_enable: 0
 php_xdebug_coverage_enable: 0
 php_xdebug_cli_disable: yes


### PR DESCRIPTION
Include php_xdebug_version in default.config.yml to provide visibility to this option.