### PR TITLE
Add Debian10 for pecl.

### DIFF
--- a/provisioning/roles/geerlingguy.php-pecl/.travis.yml
+++ b/provisioning/roles/geerlingguy.php-pecl/.travis.yml
@@ -9,6 +9,7 @@ env:
     - MOLECULE_DISTRO: centos7
     - MOLECULE_DISTRO: ubuntu1804
     - MOLECULE_DISTRO: debian9
+    - MOLECULE_DISTRO: debian10
 
 install:
   # Install test dependencies.

--- a/provisioning/roles/geerlingguy.php-pecl/vars/Debian-10.yml
+++ b/provisioning/roles/geerlingguy.php-pecl/vars/Debian-10.yml
@@ -1,0 +1,2 @@
+---
+php_pecl_package: php-pear


### PR DESCRIPTION
When I use the base image geerlingguy/drupal-vm and want to install pecl the installation fails since it looks for the php-pecl package which should be php-pear.

Just from looking at other roles I presume that this change is sufficient but at least on the site I initially tested with, adding that file did not produce the desired change and I edited Debian.yml there, too.

This should fix some of the issues originally reported in #1897. 