### PR TITLE
🐍 point to the Python 3 interpreter in PATH

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -45,7 +45,7 @@ vagrant_plugins:
   - name: vagrant-vbguest
   - name: vagrant-hostsupdater
 
-ansible_python_interpreter: /usr/bin/python3
+ansible_python_interpreter: python3
 
 # Minimum required versions.
 drupalvm_vagrant_version_min: '2.2.0'


### PR DESCRIPTION
For Mac developers using [Homebrew](https://brew.sh/), this edit will be helpful as most of them won't have Python 3 in `/usr/bin`