### PR TITLE
Update Linux documentation with Debian 10 instructions

### DIFF
--- a/docs/getting-started/installation-linux.md
+++ b/docs/getting-started/installation-linux.md
@@ -14,9 +14,13 @@ Some older Ubuntu Desktop installations don't include NFS support by default, so
 
 ### Debian
 
-A regular desktop install of Debian 10 doesn't include NFS. You'll see a message, `It appers your machine doesn't support nfs, or there is not an adapter to enable NFS on this machine for Vagrant. Please verify that `nfsd`is installed on your machine, and try again.`. You need to install `sudo apt install -y nfs-common nfs-kernel-server`. After that, you should be able to restart the machine
+A regular desktop install of Debian 10 doesn't include NFS. You'll see a message,
 
-If you see `drupalvm: Warning: Connection reset. Retrying...` and it ends with it timing out. You should be able to create a `Vagrantfile.local` and add `config.vm.boot_timeout = 600`. The default value is 300, so we are just doubling it. If it still comes back, you can increase it as needed.
+> It appers your machine doesn't support NFS, or there is not an adapter to enable NFS on this machine for Vagrant. Please verify that `nfsd`is installed on your machine, and try again. If you're on Windows, NFS isn't supported. If the problem persists, please contact Vagrant suppport.
+
+You need to install `sudo apt install -y nfs-common nfs-kernel-server`. After that, restart the Debian machine. 
+
+If you see `drupalvm: Warning: Connection reset. Retrying...` and it ends with it timing out. You need to create a `Vagrantfile.local` and add `config.vm.boot_timeout = 600`. The default value is 300, so we are just doubling it. If it still comes back, you can increase it as needed.
 
 ### Fedora
 

--- a/docs/getting-started/installation-linux.md
+++ b/docs/getting-started/installation-linux.md
@@ -12,6 +12,12 @@ Always make sure your workstation is up to date (e.g. `apt-get update && apt-get
 
 Some older Ubuntu Desktop installations don't include NFS support by default, so if you get a message like `It appears your machine doesn't support NFS`, then you should do the following to install NFS server: `sudo apt-get install -y nfs-server`.
 
+### Debian
+
+A regular desktop install of Debian 10 doesn't include NFS. You'll see a message, `It appers your machine doesn't support nfs, or there is not an adapter to enable NFS on this machine for Vagrant. Please verify that `nfsd`is installed on your machine, and try again.`. You need to install `sudo apt install -y nfs-common nfs-kernel-server`. After that, you should be able to restart the machine
+
+If you see `drupalvm: Warning: Connection reset. Retrying...` and it ends with it timing out. You should be able to create a `Vagrantfile.local` and add `config.vm.boot_timeout = 600`. The default value is 300, so we are just doubling it. If it still comes back, you can increase it as needed.
+
 ### Fedora
 
 Under Fedora, you might encounter a message like the following upon the first time you use VirtualBox or Vagrant:


### PR DESCRIPTION
Instructions include how to install NFS and increase boot timeout. 

I've been helping someone out with this and they've had both issues. I''ve been recreating from a MacOS host so maybe the timeout I'm using could be lowered but they're also seeing the timeout issue.

More info on my setup, 
- MacOS host (Catalina 10.15.5, VirtualBox 6.1.10) running a Debian 10.4.0 guest. Debian there was installed using the netinstall, gnome desktop on `tasksel`. It then acts as a host which in turns runs vagrant (2.2.9) +virtualbox (6.1.10) with an Ubuntu guest (geerlingguy/drupal-vm) 

If someone wants to test recreate and has similar setup, I'll add that on the Mac host I had to enable the "Enable Nested VT-x/AMD-V" checkbox. It shows as disabled but running `$ VBoxManage modifyvm vm-name --nested-hw-virt on` works, [source](https://stackoverflow.com/a/56973830/1392131). I didn't test if I needed "Enable PAE/NX", but I also enabled it.