### PR TITLE
Update README.md - installing Drupal 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ There are a couple places where you can customize the VM for your needs:
   - `config.yml`: Override any of the default VM configuration from `default.config.yml`; customize almost any aspect of any software installed in the VM (more about [configuring Drupal VM](http://docs.drupalvm.com/en/latest/getting-started/configure-drupalvm/).
   - `drupal.composer.json` or `drupal.make.yml`: Contains configuration for the Drupal core version, modules, and patches that will be downloaded on Drupal's initial installation (you can build using Composer, Drush make, or your own codebase).
 
+If you want to use Drupal 8 on the initial install, do the following:
+
+  1. Set `drupal_major_version: 8` inside `config.yml`.
+  2. Set `drupal_composer_project_package: "drupal/recommended-project:^8@dev" inside `config.yml`.
+  
+  
 If you want to use Drupal 7 on the initial install, do the following:
 
   1. Switch to using a [Drush Make file](http://docs.drupalvm.com/en/latest/deployment/drush-make/).

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ There are a couple places where you can customize the VM for your needs:
 If you want to use Drupal 8 on the initial install, do the following:
 
   1. Set `drupal_major_version: 8` inside `config.yml`.
-  2. Set `drupal_composer_project_package: "drupal/recommended-project:^8@dev" inside `config.yml`.
+  2. Set `drupal_composer_project_package: "drupal/recommended-project:^8@dev"` inside `config.yml`.
   
   
 If you want to use Drupal 7 on the initial install, do the following:


### PR DESCRIPTION
First ever pull request - please be gentle:)

I got very confused trying to override the default Drupal 9 installation. I'm proposing an addition to the README to add some clarification. It's far from perfect, there are a couple of additions I would like to make but don't know how to

1. I don't understand the relationship between drupal_major_version and drupal_composer_project_package. drupal_major_version seems to have no affect on the default install, but somewhere on the web (can't find it now) it is the recommended solution. Perhaps just an update to the default.config.yml to link the two variables together would help?

2, I would like to add a pointer to the available versions e.g. https://www.drupal.org/project/drupal/releases or  "For a specific version, use drupal/recommended-project:8.8.0.  For all available versions, use the shell with composer show drupal/recommended-project --all." 