### PR TITLE
Fixes syntax errors in example.drupal.composer.json #2094

### DIFF
--- a/example.drupal.composer.json
+++ b/example.drupal.composer.json
@@ -20,7 +20,7 @@
         "drupal/core-composer-scaffold": "^9",
         "drupal/core-project-message": "^9",
         "drupal/core-recommended": "^9",
-        "drush/drush:^10"
+        "drush/drush": "^10"
     },
     "conflict": {
         "drupal/drupal": "*"
@@ -58,7 +58,7 @@
             "web/themes/custom/{$name}": [
                 "type:drupal-custom-theme"
             ]
-        },
+        }
     },
     "config": {
         "process-timeout": 1200


### PR DESCRIPTION
Long time-user, first-time pull requester. I found some errors trying to copy and use the composer.json in ./example.drupal.composer.json and this commit fixes them.