### PR TITLE
Fixes #2099: Prestissimo not needed with Composer 2.x

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -278,8 +278,7 @@ composer_path: /usr/bin/composer
 composer_home_path: "/home/{{ drupalvm_user }}/.composer"
 composer_home_owner: "{{ drupalvm_user }}"
 composer_home_group: "{{ drupalvm_user }}"
-composer_global_packages:
-  - { name: hirak/prestissimo, release: '^0.3' }
+composer_global_packages: []
 
 # Run specified scripts before or after VM is provisioned. Use {{ playbook_dir }}
 # to reference the provisioning/ folder in Drupal VM or {{ config_dir }} to

--- a/docs/other/wordpress-other-applications.md
+++ b/docs/other/wordpress-other-applications.md
@@ -42,7 +42,6 @@ installed_extras:
 
 # Add wp-cli
 composer_global_packages:
-  - { name: hirak/prestissimo, release: '^0.3' }
   - { name: wp-cli/wp-cli, release: '^1.0.0' }
 ```
 

--- a/examples/scripts/pareview.sh
+++ b/examples/scripts/pareview.sh
@@ -9,7 +9,6 @@
 #       - "../examples/scripts/pareview.sh"
 #
 #     composer_global_packages:
-#       - { name: hirak/prestissimo, release: '^0.3' }
 #       - { name: drupal/coder, release: '^' }
 #
 #     nodejs_version: "6.x"


### PR DESCRIPTION
Fixes #2099 

I don't know if there is a more sophisticated way to deal with this, but by default, Composer 2.x is installed on new projects, and this solution got me past the provisioning error. Composer 2 has `hirak/prestissimo` 's parallel download feature built in now.