### PR TITLE
Add option to disable nfs_export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The `hirak/prestissimo` package was removed from `composer_global_packages` (and
 
 ### Improvements
 
-  * N/A
+  * #2108: Default synced folder nfs_export to `vagrant_synced_folder_default_nfs_export` if unset.
 
 ### Bugfixes
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -100,6 +100,7 @@ Vagrant.configure('2') do |config|
       id: synced_folder['id'],
       create: synced_folder.fetch('create', false),
       mount_options: synced_folder.fetch('mount_options', []),
+      nfs_export: synced_folder.fetch('nfs_export', vconfig['vagrant_synced_folder_default_nfs_export']),
       nfs_udp: synced_folder.fetch('nfs_udp', false)
     }
     synced_folder.fetch('options_override', {}).each do |key, value|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -163,6 +163,7 @@ Vagrant.configure('2') do |config|
     config.cache.enable :generic, cache_dir: '/home/vagrant/.composer/cache'
     config.cache.synced_folder_opts = {
       type: vconfig['vagrant_synced_folder_default_type'],
+      nfs_export: vconfig['vagrant_synced_folder_default_nfs_export'],
       nfs_udp: false
     }
   end

--- a/default.config.yml
+++ b/default.config.yml
@@ -8,6 +8,7 @@ vagrant_box: geerlingguy/drupal-vm
 
 vagrant_user: vagrant
 vagrant_synced_folder_default_type: nfs
+vagrant_synced_folder_default_nfs_export: true
 vagrant_gui: false
 
 # If you need to run multiple instances of Drupal VM, set a unique hostname,


### PR DESCRIPTION
Allow DrupalVM to leave the /etc/exports file alone and let me manage it.