### PR TITLE
Replace php_opcache_enabled_in_ini with php_opcache_enable

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -263,7 +263,7 @@ php_display_errors: "On"
 php_display_startup_errors: "On"
 php_realpath_cache_size: "1024K"
 php_sendmail_path: "/opt/mailhog/mhsendmail"
-php_opcache_enabled_in_ini: true
+php_opcache_enable: "1"
 php_opcache_memory_consumption: "192"
 php_opcache_max_accelerated_files: 4096
 php_max_input_vars: "4000"


### PR DESCRIPTION
The `php_opcache_enabled_in_ini` was removed from [ansible-role-php](https://github.com/geerlingguy/ansible-role-php) in [commit b9f0a61](https://github.com/geerlingguy/ansible-role-php/commit/b9f0a6172000fb834a95fb30f5c46cafe03f4331).

This means that within Drupal VM, the only place I can find `php_opcache_enabled_in_ini` is in default.config.yml. Switching this out for the `php_opcache_enable` will allow toggling the state of the opcache.