### PR TITLE
fix: add ansible install_mode "pip3"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -111,6 +111,7 @@ Vagrant.configure('2') do |config|
   config.vm.provision 'drupalvm', type: provisioner do |ansible|
     ansible.compatibility_mode = '2.0'
     ansible.playbook = playbook
+    ansible.install_mode = "pip3"
     ansible.extra_vars = {
       config_dir: config_dir,
       drupalvm_env: drupalvm_env,
@@ -119,7 +120,7 @@ Vagrant.configure('2') do |config|
     ansible.raw_arguments = Shellwords.shellsplit(ENV['DRUPALVM_ANSIBLE_ARGS']) if ENV['DRUPALVM_ANSIBLE_ARGS']
     ansible.tags = ENV['DRUPALVM_ANSIBLE_TAGS']
     # Use pip to get the latest Ansible version when using ansible_local.
-    provisioner == :ansible_local && ansible.install_mode = 'pip'
+    provisioner == :ansible_local && ansible.install_mode = 'pip3'
   end
 
   # VMware Fusion.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -111,7 +111,7 @@ Vagrant.configure('2') do |config|
   config.vm.provision 'drupalvm', type: provisioner do |ansible|
     ansible.compatibility_mode = '2.0'
     ansible.playbook = playbook
-    ansible.install_mode = "pip3"
+    ansible.install_mode = 'pip3'
     ansible.extra_vars = {
       config_dir: config_dir,
       drupalvm_env: drupalvm_env,


### PR DESCRIPTION
This fixes an issue that was recently created by the release of a new version of the script here: https://bootstrap.pypa.io/get-pip.py.

TL;DR — they dropped support for Python2 and this now requires pip3. Maybe worth noting I may have had to manually install Python3 via SSH into the box, but I may have also already had it and it was a step I just duplicated. Either way — this fixes issues folks should be having as of this last Saturday.