### PR TITLE
Remove elastic search heap options dependency

### DIFF
--- a/provisioning/roles/geerlingguy.elasticsearch/tasks/main.yml
+++ b/provisioning/roles/geerlingguy.elasticsearch/tasks/main.yml
@@ -19,7 +19,6 @@
     mode: 0660
   with_items:
     - /etc/elasticsearch/elasticsearch.yml
-    - /etc/elasticsearch/jvm.options.d/heap.options
   notify: restart elasticsearch
 
 - name: Force a restart if configuration has changed.


### PR DESCRIPTION
Remove line `/etc/elasticsearch/jvm.options.d/heap.options`. This line causes the whole build to fail since it doesn't exist.