### PR TITLE
Fixes #2144: Change docs on native synced folders to use explicit type

### DIFF
--- a/docs/getting-started/syncing-folders.md
+++ b/docs/getting-started/syncing-folders.md
@@ -45,13 +45,13 @@ There are a number of issues people encounter with synced folders from time to t
 
 ### Using Native Synced Folders
 
-You can use a native synced folder, which should work pretty flawlessly on any platform, but with a potential serious performance downside (compared to other synced folder methods). Just set `type` to `""`.
+You can use a native synced folder, which should work pretty flawlessly on any platform, but with a potential serious performance downside (compared to other synced folder methods). Just set `type` to `virtualbox`.
 
 ```yaml
 vagrant_synced_folders:
   - local_path: .
     destination: /var/www/docroot
-    type: ""
+    type: virtualbox
     create: true
 ```
 
@@ -65,7 +65,7 @@ If you're encountering errors where Drupal or some other software inside the VM 
 vagrant_synced_folders:
   - local_path: .
     destination: /var/www/drupalvm
-    type: ""
+    type: virtualbox
     create: true
     mount_options: ["dmode=775", "fmode=664"]
     options_override:

--- a/docs/other/performance.md
+++ b/docs/other/performance.md
@@ -59,7 +59,7 @@ vagrant_synced_folders:
   # Use a slower but two-way sync for configuration sync directory.
   - local_path: config/drupal
     destination: /var/www/drupal/config/drupal
-    type: "" # Or smb/nfs if available
+    type: virtualbox # Or smb/nfs if available
     create: true
 ```
 
@@ -82,7 +82,7 @@ Another option for the more adventurous is to manually install and configure Win
 
 GuyPaddock's [fork of `vagrant-winnfsd`](https://github.com/GuyPaddock/vagrant-winnfsd) adds logging and debug messages. You can replace the vagrant-winnfsd gem inside `.vagrant.d\gems\gems` to use it instead. For further caveats, please read through [vagrant-winnfsd issue #12](https://github.com/winnfsd/vagrant-winnfsd/issues/12#issuecomment-78195957), and make the following changes to `config.yml`:
 
-    vagrant_synced_folder_default_type: ""
+    vagrant_synced_folder_default_type: virtualbox
 
 Add `mount_options` to your synced folder to avoid an error:
 


### PR DESCRIPTION
Another option is to only set `type` if truthy.